### PR TITLE
update Jupyter Readme for notebook sharing

### DIFF
--- a/content/jupyter-readme/README.ipynb
+++ b/content/jupyter-readme/README.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "You can request personal account by contacting the email on the login page.  With a personal account, you will have a production environment with private workspace and no computing resource limitation.\n",
     "\n",
-    "## File Layout\n",
+    "## Home Directory Layout\n",
     "\n",
     "```\n",
     "/notebook_dir/\n",

--- a/content/jupyter-readme/README.ipynb
+++ b/content/jupyter-readme/README.ipynb
@@ -19,6 +19,18 @@
     "\n",
     "You can request personal account by contacting the email on the login page.  With a personal account, you will have a production environment with private workspace and no computing resource limitation.\n",
     "\n",
+    "## File Layout\n",
+    "\n",
+    "```\n",
+    "/notebook_dir/\n",
+    "├── README.ipynb        # This file, read-only.\n",
+    "├── pavics-homepage     # Tutorial notebooks from the PAVICS homepage, read-only.\n",
+    "├── tutorial-notebooks  # Other tutorial notebooks, read-only.\n",
+    "├── public              # Public share of all other users on this system, read-only.\n",
+    "├── mypublic            # Your public share visible to all other users, do not put anything private in there.\n",
+    "└── writable-workspace  # Your personal writable workspace, private to you only.\n",
+    "```\n",
+    "\n",
     "## Example: Computing a climate index at a given coordinate"
    ]
   },
@@ -220,7 +232,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -234,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Explain the new `mypublic` and `public` folder (PR https://github.com/bird-house/birdhouse-deploy/pull/190).

Show `/notebook_dir/` is the notebook root (issue https://github.com/Ouranosinc/pavics-sdi/issues/227).

What is not shown but will be effective is I've moved this file that is originally at https://github.com/bird-house/birdhouse-deploy/blob/537f997a1a9a57901b5072cc6c6f950f92f37e9a/docs/source/notebooks/README.ipynb to this repo since this file is fairly Ouranos specific and has some overlapping info with the landing homepage.

I am setting up so we can harmonize this `README.ipynb` better with the landing homepage in the future.

Deployment of this README file is handled by PR https://github.com/bird-house/birdhouse-deploy-ouranos/pull/15.

