### PR TITLE
Take url anchor into account when loading page

### DIFF
--- a/src/assets/setup.js
+++ b/src/assets/setup.js
@@ -68,7 +68,8 @@ $(function() {
       // Get the anchor at the end of the url, e.g. "src/hydrology.html#c" --> "#c"
       let anchor = window.location.hash;
       if (anchor) {
-        // If the anchor is set, set the corresponding tab/item to active
+        // If the anchor is set, first set the default (i.e. the first) tab and item to inactive, then
+        // set the user selected tab and item to active
         $("#a.tab-pane").removeClass("show active");
         $(`${anchor}.tab-pane`).addClass("show active");
         $("a.nav-link").each(function() {

--- a/src/assets/setup.js
+++ b/src/assets/setup.js
@@ -31,12 +31,12 @@ $(function() {
         if ($(item).data("iframe")) {
 
           // Update the location bar url with the item hash
-          let h = "#" + item.id;
-          if (history.pushState) {
-            history.pushState(null, null, h);
+          let anchor = "#" + item.id;
+          if (window.history.pushState) {
+            window.history.pushState(null, null, anchor);
           }
           else {
-            location.hash = h;
+            window.location.hash = anchor;
           }
 
           html = ''

--- a/src/assets/setup.js
+++ b/src/assets/setup.js
@@ -29,6 +29,16 @@ $(function() {
     function activateIframe() {
       $(".tab-pane.active").each(function(index, item) {
         if ($(item).data("iframe")) {
+
+          // Update the location bar url with the item hash
+          let h = "#" + item.id;
+          if (history.pushState) {
+            history.pushState(null, null, h);
+          }
+          else {
+            location.hash = h;
+          }
+
           html = ''
 
           // Add pavics link
@@ -54,6 +64,25 @@ $(function() {
 
     // Called after loading of page is complete
     function afterLoad() {
+
+      // Get the anchor at the end of the url, e.g. "src/hydrology.html#c" --> "#c"
+      let anchor = window.location.hash;
+      if (anchor) {
+        // If the anchor is set, set the corresponding tab/item to active
+        $("#a.tab-pane").removeClass("show active");
+        $(`${anchor}.tab-pane`).addClass("show active");
+        $("a.nav-link").each(function() {
+          if ($(this).attr("href") === "#a") {
+            $(this).removeClass("active")
+          }
+        });
+        $("a.nav-link").each(function() {
+          if ($(this).attr("href") === anchor) {
+            $(this).addClass("active")
+          }
+        });
+      }
+
       // Activate initial iframe
       activateIframe()
 


### PR DESCRIPTION
This should make sure that loading `https://pavics.ouranos.ca/datasets.html#b` (i.e. url with an anchor) correctly activates the second tab (corresponding to item `b`). Should work with all pages and languages.