### PR TITLE
Fix jenkins failure due to import ordering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,8 @@ repos:
       - id: nbqa-black
       - id: nbqa-pyupgrade
         args: [--py37-plus]
-      - id: nbqa-isort
+      # disable import re-ordering for https://github.com/roocs/clisops/issues/144
+      #- id: nbqa-isort
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb
+++ b/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb
@@ -772,10 +772,10 @@
     "import geopandas as gpd\n",
     "import matplotlib.pyplot as plt\n",
     "import xarray as xr\n",
-    "from clisops.core import subset\n",
     "from dask.diagnostics import ProgressBar\n",
     "from siphon.catalog import TDSCatalog\n",
     "from xclim import atmos\n",
+    "from clisops.core import subset\n",
     "\n",
     "warnings.simplefilter(\"ignore\")\n",
     "# TODO change address\n",
@@ -1853,7 +1853,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,10 @@
+# conda env create -f environment-dev.yml
+
+name: PAVICS-landing
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  # then `pre-commit install` to initialize
+  - pre-commit


### PR DESCRIPTION
Change import ordering in homepage notebook 3 to avoid the following warnings that breaks Jenkins:
```
2022-01-20 15:24:39,144 - pint.util - WARNING - Redefining 'year' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,145 - pint.util - WARNING - Redefining 'yr' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,146 - pint.util - WARNING - Redefining 'degree_Celsius' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,147 - pint.util - WARNING - Redefining '°C' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,147 - pint.util - WARNING - Redefining 'celsius' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,148 - pint.util - WARNING - Redefining 'degC' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,148 - pint.util - WARNING - Redefining 'degreeC' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,149 - pint.util - WARNING - Redefining 'C' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,149 - pint.util - WARNING - Redefining 'deg_C' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,150 - pint.util - WARNING - Redefining 'degrees_north' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,151 - pint.util - WARNING - Redefining 'degrees_east' (<class 'pint.definitions.UnitDefinition'>)
2022-01-20 15:24:39,151 - pint.util - WARNING - Redefining '[speed]' (<class 'pint.definitions.DimensionDefinition'>)
```
See https://github.com/roocs/clisops/issues/144

Jenkins now passing http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/master/1424/console.

Also
* disable the automatic import ordering in the pre-commit hook to prevent the issue to come back again on commit
* add `environment-dev.yml` to install the pre-commit tool
