### PR TITLE
Help external parser describe the website

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
     <title>PAVICS</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" contents="PAVICS is a virtual laboratory facilitating the analysis of climate data. It provides access to several data collections ranging from observations, climate projections and reanalyses. It also provides a Python programming environment to analyze this data without the need to download it. This working environment is constantly updated with the most efficient libraries for climate data analysis, in addition to ensuring quality control on the provided data and associated metadata.">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <link rel="stylesheet" href="assets/fontawesome.css">
     <link rel="stylesheet" href="assets/setup.css">


### PR DESCRIPTION
This adds a "meta" description field so we control what external parsers use as the website's description.

For example, when pasting the page url in a email on outlook, we now get:
![image](https://user-images.githubusercontent.com/20629530/185477781-5be9f597-df4b-44ff-9793-56cf4c727f66.png)
Before we had:
![image](https://user-images.githubusercontent.com/20629530/185478073-f65aeee8-9608-4190-a15a-7240995454d1.png)

Note: this is not easy to test. For example, I wasn't able to reproduce the "before" case on my VM... 