### PR TITLE
homepage nb 3: fix for Jenkins, pint redefinition warning gone in new Jupyter env

### DIFF
--- a/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb
+++ b/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb
@@ -44,23 +44,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:pint.util:Redefining 'percent' (<TYPE_CLASSpint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining '%' (<TYPE_CLASSpint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'year' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'yr' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'C' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'd' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'h' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'degrees_north' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining 'degrees_east' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)\n",
-      "WARNING:pint.util:Redefining '[speed]' (<class 'pint.delegates.txt_defparser.plain.DerivedDimensionDefinition'>)\n",
-      "WARNING:pint.util:Redefining '[radiation]' (<TYPE_CLASSpint.delegates.txt_defparser.plain.DerivedDimensionDefinition'>)\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",


### PR DESCRIPTION
Wait for PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/121 merged before merging this one.

```
  _ PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb::Cell 0 _
  Notebook cell execution failed
  Cell 0: Cell outputs differ

  Input:
  import os

  os.environ["USE_PYGEOS"] = "0"  # force use Shapely with GeoPandas

  import warnings

  import numba

  warnings.simplefilter("ignore", category=numba.core.errors.NumbaDeprecationWarning)

  import geopandas as gpd
  import matplotlib.pyplot as plt
  import xarray as xr
  from clisops.core import subset
  from dask.diagnostics import ProgressBar
  from siphon.catalog import TDSCatalog
  from xclim import atmos

  warnings.simplefilter("ignore")
  # TODO change address
  url = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/simulations/bias_adjusted/cmip5/ouranos/cb-oura-1.0/catalog.xml"  # TEST_USE_PROD_DATA

  # Create Catalog
  cat = TDSCatalog(url)

  # Subset over the Gasp�� peninsula in eastern Quebec
  gaspe = gpd.GeoDataFrame.from_file(
      "/notebook_dir/pavics-homepage/tutorial_data/gaspesie_mrc.geojson"
  )
  ds = subset.subset_shape(
      xr.open_dataset(cat.datasets[0].access_urls["OPENDAP"], chunks=dict(time=256)),
      shape=gpd.GeoDataFrame(geometry=gaspe.buffer(0.05)),
  )

  # What we see here is only a representation of the full content, the entire data set hasn't been loaded.
  display(ds)

  # plot of single day tasmin
  a = ds.tasmin.isel(time=0).plot(figsize=(10, 4))

  Traceback:
  Missing output fields from running code: {'stderr'}
```