### PR TITLE
Mastodon Feed

### DIFF
--- a/src/assets/template.html
+++ b/src/assets/template.html
@@ -67,7 +67,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm" style="text-align: center;">Contact: <a href="mailto:pavics@ouranos.ca">pavics@ouranos.ca</a></div>
-      <div class="col-sm" style="text-align: center;">Twitter: <a href="https://twitter.com/PAVICSOuranos" target="_blank">@PAVICSOuranos</a></div>
+      <div class="col-sm" style="text-align: center;">Mastodon: <a href="https://fosstodon.org/@pavics" target="_blank">@pavics@fosstodon</a></div>
       <div class="col-sm" style="text-align: center;">Legal: <a href="https://github.com/Ouranosinc/Legal-Ouranos/blob/master/PAVICS/PAVICS_Conditions_PrivacyPolicy_en_fr.md" target="_blank">PAVICS Conditions</a></div>
     </div>
   </div>

--- a/src/assets/template_fr.html
+++ b/src/assets/template_fr.html
@@ -67,7 +67,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm" style="text-align: center;">Coordonnées: <a href="mailto:pavics@ouranos.ca">pavics@ouranos.ca</a></div>
-      <div class="col-sm" style="text-align: center;">Twitter: <a href="https://twitter.com/PAVICSOuranos" target="_blank">@PAVICSOuranos</a></div>
+      <div class="col-sm" style="text-align: center;">Mastodon: <a href="https://fosstodon.org/@pavics" target="_blank">@pavics@fosstodon</a></div>
       <div class="col-sm" style="text-align: center;">Conditions: <a href="https://github.com/Ouranosinc/Legal-Ouranos/blob/master/PAVICS/PAVICS_Conditions_PrivacyPolicy_en_fr.md" target="_blank">PAVICS Conditions d'utilisation</a></div>
     </div>
   </div>

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" contents="PAVICS is a virtual laboratory facilitating the analysis of climate data. It provides access to several data collections ranging from observations, climate projections and reanalyses. It also provides a Python programming environment to analyze this data without the need to download it. This working environment is constantly updated with the most efficient libraries for climate data analysis, in addition to ensuring quality control on the provided data and associated metadata.">
+    <link rel="me" href="https://fosstodon.org/@pavics">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <link rel="stylesheet" href="assets/fontawesome.css">
     <link rel="stylesheet" href="assets/setup.css">

--- a/src/pages/news.html
+++ b/src/pages/news.html
@@ -7,6 +7,6 @@
 
 <div class="container">
   <div style="padding-left: 15%; padding-right: 15%">
-    <a class="twitter-timeline" data-theme="light" data-chrome="noheader transparent" href="https://twitter.com/PAVICSOuranos?ref_src=twsrc%5Etfw">Tweets by PAVICSOuranos</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <a class="mastodon-feed" href="https://fosstodon.org/@pavics" data-toot-limit="4">Toots by @pavics@fosstodon.org </a> <script type="module" src="https://esm.sh/emfed@1"></script>
   </div>
 </div>

--- a/src/pages/news.html
+++ b/src/pages/news.html
@@ -7,6 +7,6 @@
 
 <div class="container">
   <div style="padding-left: 15%; padding-right: 15%">
-    <a class="mastodon-feed" href="https://fosstodon.org/@pavics" data-toot-limit="4">Toots by @pavics@fosstodon.org </a> <script type="module" src="https://esm.sh/emfed@1"></script>
+    <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="500" height="600" src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Fpavics&theme=auto&size=100&header=true&replies=false&boosts=false"></iframe>
   </div>
 </div>

--- a/src/pages/news_fr.html
+++ b/src/pages/news_fr.html
@@ -7,6 +7,6 @@
 
 <div class="container">
   <div style="padding-left: 15%; padding-right: 15%">
-    <a class="twitter-timeline" data-theme="light" data-chrome="noheader transparent" href="https://twitter.com/PAVICSOuranos?ref_src=twsrc%5Etfw">Tweets by PAVICSOuranos</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <a class="mastodon-feed" href="https://fosstodon.org/@pavics" data-toot-limit="4">Toots by @pavics@fosstodon.org </a> <script type="module" src="https://esm.sh/emfed@1"></script>
   </div>
 </div>

--- a/src/pages/news_fr.html
+++ b/src/pages/news_fr.html
@@ -7,6 +7,6 @@
 
 <div class="container">
   <div style="padding-left: 15%; padding-right: 15%">
-    <a class="mastodon-feed" href="https://fosstodon.org/@pavics" data-toot-limit="4">Toots by @pavics@fosstodon.org </a> <script type="module" src="https://esm.sh/emfed@1"></script>
+    <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="500" height="600" src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Fpavics&theme=auto&size=100&header=true&replies=false&boosts=false"></iframe>
   </div>
 </div>


### PR DESCRIPTION
### Changes

* Replaces Twitter feed with Mastodon feed
* Changes the default template twitter link to point to Mastodon instead
* Adds a verification link to the main page to verify @pavics@fosstodon.org