### PR TITLE
homepage nb2: update output to fix Jenkins

### DIFF
--- a/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-2Subsetting.ipynb
+++ b/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-2Subsetting.ipynb
@@ -40,10 +40,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:27:45.810181Z",
-     "iopub.status.busy": "2025-11-06T01:27:45.808407Z",
-     "iopub.status.idle": "2025-11-06T01:28:20.635321Z",
-     "shell.execute_reply": "2025-11-06T01:28:20.634479Z"
+     "iopub.execute_input": "2025-11-13T01:27:47.537995Z",
+     "iopub.status.busy": "2025-11-13T01:27:47.537602Z",
+     "iopub.status.idle": "2025-11-13T01:28:29.671182Z",
+     "shell.execute_reply": "2025-11-13T01:28:29.670637Z"
     },
     "tags": []
    },
@@ -422,11 +422,11 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 1TB\n",
-       "Dimensions:  (lat: 801, lon: 1700, time: 27667)\n",
+       "Dimensions:  (lat: 801, lon: 1700, time: 27698)\n",
        "Coordinates:\n",
        "  * lat      (lat) float32 3kB 10.0 10.1 10.2 10.3 10.4 ... 89.7 89.8 89.9 90.0\n",
        "  * lon      (lon) float32 7kB -179.9 -179.8 -179.7 -179.6 ... -10.2 -10.1 -10.0\n",
-       "  * time     (time) datetime64[ns] 221kB 1950-01-01 1950-01-02 ... 2025-09-30\n",
+       "  * time     (time) datetime64[ns] 222kB 1950-01-01 1950-01-02 ... 2025-10-31\n",
        "Data variables:\n",
        "    tas      (time, lat, lon) float32 151GB dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;\n",
        "    tasmin   (time, lat, lon) float32 151GB dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;\n",
@@ -450,11 +450,11 @@
        "    abstract:                ERA5-Land provides hourly high resolution inform...\n",
        "    dataset_description:     https://www.ecmwf.int/en/era5-land\n",
        "    attribution:             Contains modified Copernicus Climate Change Serv...\n",
-       "    citation:                Muñoz Sabater, J., (2021): ERA5-Land hourly data...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-13b1f33a-f7e1-43ff-b2bd-622c810d137c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-13b1f33a-f7e1-43ff-b2bd-622c810d137c' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 801</li><li><span class='xr-has-index'>lon</span>: 1700</li><li><span class='xr-has-index'>time</span>: 27667</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-94c2588f-cc49-4a8f-8a7f-0608d56e23d6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-94c2588f-cc49-4a8f-8a7f-0608d56e23d6' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>10.0 10.1 10.2 ... 89.8 89.9 90.0</div><input id='attrs-97e54c44-f813-4f12-b847-9bffc2fe8616' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-97e54c44-f813-4f12-b847-9bffc2fe8616' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5c8ad400-5984-43c6-918d-34f036120358' class='xr-var-data-in' type='checkbox'><label for='data-5c8ad400-5984-43c6-918d-34f036120358' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([10. , 10.1, 10.2, ..., 89.8, 89.9, 90. ], shape=(801,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... -10.1 -10.0</div><input id='attrs-856d50ed-f9e0-4d99-8962-45ff1125f5a1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-856d50ed-f9e0-4d99-8962-45ff1125f5a1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-49e84a19-a8cf-40d5-af06-205b738248e6' class='xr-var-data-in' type='checkbox'><label for='data-49e84a19-a8cf-40d5-af06-205b738248e6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-179.9, -179.8, -179.7, ...,  -10.2,  -10.1,  -10. ],\n",
-       "      shape=(1700,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1950-01-01 ... 2025-09-30</div><input id='attrs-b7749797-17ef-4b2e-a6f4-97990b67a47c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b7749797-17ef-4b2e-a6f4-97990b67a47c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1e4fdade-693c-4467-b852-d5b5526bedf0' class='xr-var-data-in' type='checkbox'><label for='data-1e4fdade-693c-4467-b852-d5b5526bedf0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1950-01-01T00:00:00.000000000&#x27;, &#x27;1950-01-02T00:00:00.000000000&#x27;,\n",
-       "       &#x27;1950-01-03T00:00:00.000000000&#x27;, ..., &#x27;2025-09-28T00:00:00.000000000&#x27;,\n",
-       "       &#x27;2025-09-29T00:00:00.000000000&#x27;, &#x27;2025-09-30T00:00:00.000000000&#x27;],\n",
-       "      shape=(27667,), dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f2a7618b-8d7a-4dc5-ac55-84c5fe82d2d8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f2a7618b-8d7a-4dc5-ac55-84c5fe82d2d8' class='xr-section-summary' >Data variables: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-6f0b7b01-901b-46d2-b337-e506d8bb4dfb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6f0b7b01-901b-46d2-b337-e506d8bb4dfb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e35d4ddc-0cf9-456d-bfd2-ce765491b2aa' class='xr-var-data-in' type='checkbox'><label for='data-e35d4ddc-0cf9-456d-bfd2-ce765491b2aa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:44:23] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    citation:                Muñoz Sabater, J., (2021): ERA5-Land hourly data...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-da33c403-dbce-4dc7-a9c8-688c5e814839' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-da33c403-dbce-4dc7-a9c8-688c5e814839' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 801</li><li><span class='xr-has-index'>lon</span>: 1700</li><li><span class='xr-has-index'>time</span>: 27698</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-65dd1e0c-7a7a-4259-aa2b-2acaebf5f1ba' class='xr-section-summary-in' type='checkbox'  checked><label for='section-65dd1e0c-7a7a-4259-aa2b-2acaebf5f1ba' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>10.0 10.1 10.2 ... 89.8 89.9 90.0</div><input id='attrs-1edf4e08-9e1e-4e73-8756-4677254458b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1edf4e08-9e1e-4e73-8756-4677254458b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-98d081c0-b322-4b04-9453-6689eedb8a7c' class='xr-var-data-in' type='checkbox'><label for='data-98d081c0-b322-4b04-9453-6689eedb8a7c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([10. , 10.1, 10.2, ..., 89.8, 89.9, 90. ], shape=(801,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... -10.1 -10.0</div><input id='attrs-1f986b76-98c0-4daa-b69a-56be55185873' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1f986b76-98c0-4daa-b69a-56be55185873' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3c81b21e-b42b-4445-883a-b46b9c96c695' class='xr-var-data-in' type='checkbox'><label for='data-3c81b21e-b42b-4445-883a-b46b9c96c695' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-179.9, -179.8, -179.7, ...,  -10.2,  -10.1,  -10. ],\n",
+       "      shape=(1700,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1950-01-01 ... 2025-10-31</div><input id='attrs-8c52798c-3d13-44ff-8123-036112716536' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8c52798c-3d13-44ff-8123-036112716536' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1ceb057e-935f-4d48-b418-95f36eedc6a1' class='xr-var-data-in' type='checkbox'><label for='data-1ceb057e-935f-4d48-b418-95f36eedc6a1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1950-01-01T00:00:00.000000000&#x27;, &#x27;1950-01-02T00:00:00.000000000&#x27;,\n",
+       "       &#x27;1950-01-03T00:00:00.000000000&#x27;, ..., &#x27;2025-10-29T00:00:00.000000000&#x27;,\n",
+       "       &#x27;2025-10-30T00:00:00.000000000&#x27;, &#x27;2025-10-31T00:00:00.000000000&#x27;],\n",
+       "      shape=(27698,), dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8d21245f-92c5-4240-b15d-cfafef5e2703' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8d21245f-92c5-4240-b15d-cfafef5e2703' class='xr-section-summary' >Data variables: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-0379472f-1bb3-439c-9dd8-a90065fc53e8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0379472f-1bb3-439c-9dd8-a90065fc53e8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d71430a5-a50a-4a02-86e5-b6637df10d6a' class='xr-var-data-in' type='checkbox'><label for='data-d71430a5-a50a-4a02-86e5-b6637df10d6a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:44:23] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -469,13 +469,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -520,14 +520,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -540,7 +540,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -548,7 +548,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -556,7 +556,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -572,7 +572,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -591,7 +591,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -607,16 +607,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmin</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-117188bc-c949-45ac-bd10-f73298b9b25c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-117188bc-c949-45ac-bd10-f73298b9b25c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4a2be010-5540-4cc6-8e07-aa752b6d2478' class='xr-var-data-in' type='checkbox'><label for='data-4a2be010-5540-4cc6-8e07-aa752b6d2478' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:14:43] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmin</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-4d7d5edc-2c07-433d-b346-13e317ac5236' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4d7d5edc-2c07-433d-b346-13e317ac5236' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-392d298f-9c3e-4908-a564-d80bb8ae24bf' class='xr-var-data-in' type='checkbox'><label for='data-392d298f-9c3e-4908-a564-d80bb8ae24bf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:14:43] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -631,13 +631,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -682,14 +682,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -702,7 +702,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -710,7 +710,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -718,7 +718,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -734,7 +734,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -753,7 +753,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -769,16 +769,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmax</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-7a6e9a86-998d-42ea-b58f-904d7d7ab54e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7a6e9a86-998d-42ea-b58f-904d7d7ab54e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-61f8126b-5cbb-4dd3-851a-f0c400f489bb' class='xr-var-data-in' type='checkbox'><label for='data-61f8126b-5cbb-4dd3-851a-f0c400f489bb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:23:27] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmax</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-39cf3945-ade1-45d8-bbaf-8ecf193e97a3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-39cf3945-ade1-45d8-bbaf-8ecf193e97a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ce6c9074-d686-4def-adc8-cbc1a7b800b3' class='xr-var-data-in' type='checkbox'><label for='data-ce6c9074-d686-4def-adc8-cbc1a7b800b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:23:27] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -793,13 +793,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -844,14 +844,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -864,7 +864,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -872,7 +872,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -880,7 +880,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -896,7 +896,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -915,7 +915,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -931,16 +931,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>pr</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-b2555398-b91c-4b3d-a8e9-73801a05f6f5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b2555398-b91c-4b3d-a8e9-73801a05f6f5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-04d1fe86-f517-4716-9d11-2bb18852ab94' class='xr-var-data-in' type='checkbox'><label for='data-04d1fe86-f517-4716-9d11-2bb18852ab94' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Precipitation</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Total precipitation thickness converted to mass flux using a water density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Total precipitation</dd><dt><span>original_variable :</span></dt><dd>tp</dd><dt><span>standard_name :</span></dt><dd>precipitation_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:30:54] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>pr</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-a67417da-bb86-440c-8277-9fdfb9db5cd8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a67417da-bb86-440c-8277-9fdfb9db5cd8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1fd3a3c1-c16f-456f-9fe9-0ade569bbf76' class='xr-var-data-in' type='checkbox'><label for='data-1fd3a3c1-c16f-456f-9fe9-0ade569bbf76' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Precipitation</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Total precipitation thickness converted to mass flux using a water density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Total precipitation</dd><dt><span>original_variable :</span></dt><dd>tp</dd><dt><span>standard_name :</span></dt><dd>precipitation_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:30:54] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -955,13 +955,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -1006,14 +1006,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -1026,7 +1026,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -1034,7 +1034,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1042,7 +1042,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -1058,7 +1058,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -1077,7 +1077,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -1093,16 +1093,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>prsn</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-8e34397b-c481-4386-8162-99dd9f73c747' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8e34397b-c481-4386-8162-99dd9f73c747' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0dd8faf7-6b29-409b-aeaf-d0000a5bb626' class='xr-var-data-in' type='checkbox'><label for='data-0dd8faf7-6b29-409b-aeaf-d0000a5bb626' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Snowfall flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 hour)</dd><dt><span>comments :</span></dt><dd>Converted from Snowfall (water equivalent) using a density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Snowfall</dd><dt><span>original_variable :</span></dt><dd>sf</dd><dt><span>standard_name :</span></dt><dd>snowfall_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:36:49] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>prsn</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-8036686f-daa9-4075-b440-0c2f1ce55a77' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8036686f-daa9-4075-b440-0c2f1ce55a77' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1574caa0-4765-4c77-bc10-d92cb791215e' class='xr-var-data-in' type='checkbox'><label for='data-1574caa0-4765-4c77-bc10-d92cb791215e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Snowfall flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 hour)</dd><dt><span>comments :</span></dt><dd>Converted from Snowfall (water equivalent) using a density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Snowfall</dd><dt><span>original_variable :</span></dt><dd>sf</dd><dt><span>standard_name :</span></dt><dd>snowfall_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:36:49] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1117,13 +1117,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -1168,14 +1168,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -1188,7 +1188,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -1196,7 +1196,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1204,7 +1204,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -1220,7 +1220,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -1239,7 +1239,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -1255,16 +1255,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rlds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-5d67de24-2355-4680-a33d-74bdf0adf3aa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5d67de24-2355-4680-a33d-74bdf0adf3aa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-77363dd6-4254-4245-a57a-3d2df5467525' class='xr-var-data-in' type='checkbox'><label for='data-77363dd6-4254-4245-a57a-3d2df5467525' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of thermal (also known as longwave or terrestrial) radiation emitted by the atmosphere and clouds that reaches a horizontal plane at the surface of the Earth. </dd><dt><span>original_long_name :</span></dt><dd>Surface thermal radiation downwards</dd><dt><span>original_variable :</span></dt><dd>strd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:53:12] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rlds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-a9dde24d-fb72-4d0c-98f5-ebe155e0bf18' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a9dde24d-fb72-4d0c-98f5-ebe155e0bf18' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa13e928-7b43-43ba-99fe-2810c315aabc' class='xr-var-data-in' type='checkbox'><label for='data-fa13e928-7b43-43ba-99fe-2810c315aabc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of thermal (also known as longwave or terrestrial) radiation emitted by the atmosphere and clouds that reaches a horizontal plane at the surface of the Earth. </dd><dt><span>original_long_name :</span></dt><dd>Surface thermal radiation downwards</dd><dt><span>original_variable :</span></dt><dd>strd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:53:12] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1279,13 +1279,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -1330,14 +1330,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -1350,7 +1350,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -1358,7 +1358,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1366,7 +1366,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -1382,7 +1382,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -1401,7 +1401,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -1417,16 +1417,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rls</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-672724e4-419c-4b20-a109-14039cc5afcb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-672724e4-419c-4b20-a109-14039cc5afcb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dcd63c36-564e-4565-abaf-8158bbad7d00' class='xr-var-data-in' type='checkbox'><label for='data-dcd63c36-564e-4565-abaf-8158bbad7d00' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Thermal radiation (also known as longwave or terrestrial radiation) refers to radiation emitted by the atmosphere, clouds and the surface of the Earth. This parameter is the difference between downward and upward thermal radiation at the surface of the Earth. It the amount passing through a horizontal plane.</dd><dt><span>original_long_name :</span></dt><dd>Surface net thermal radiation</dd><dt><span>original_variable :</span></dt><dd>str</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:03:58] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rls</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-52741e74-97d8-4cfa-8452-3d32f55f5625' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-52741e74-97d8-4cfa-8452-3d32f55f5625' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-479564f1-98ab-48a7-9e20-1996c0984fb7' class='xr-var-data-in' type='checkbox'><label for='data-479564f1-98ab-48a7-9e20-1996c0984fb7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Thermal radiation (also known as longwave or terrestrial radiation) refers to radiation emitted by the atmosphere, clouds and the surface of the Earth. This parameter is the difference between downward and upward thermal radiation at the surface of the Earth. It the amount passing through a horizontal plane.</dd><dt><span>original_long_name :</span></dt><dd>Surface net thermal radiation</dd><dt><span>original_variable :</span></dt><dd>str</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:03:58] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1441,13 +1441,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -1492,14 +1492,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -1512,7 +1512,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -1520,7 +1520,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1528,7 +1528,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -1544,7 +1544,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -1563,7 +1563,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -1579,16 +1579,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rsds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-2602d41a-1b3a-455a-85b2-a86c7ebe22d3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2602d41a-1b3a-455a-85b2-a86c7ebe22d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4a5b4244-3106-4344-966e-bd7318937144' class='xr-var-data-in' type='checkbox'><label for='data-4a5b4244-3106-4344-966e-bd7318937144' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth. This parameter comprises both direct and diffuse solar radiation</dd><dt><span>original_long_name :</span></dt><dd>Surface solar radiation downwards</dd><dt><span>original_variable :</span></dt><dd>ssrd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:13:31] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rsds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-29b255b7-5b6f-472b-aadd-30bf1611cc66' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-29b255b7-5b6f-472b-aadd-30bf1611cc66' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6c12b80c-3832-4d74-b3ac-1d531aa65581' class='xr-var-data-in' type='checkbox'><label for='data-6c12b80c-3832-4d74-b3ac-1d531aa65581' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth. This parameter comprises both direct and diffuse solar radiation</dd><dt><span>original_long_name :</span></dt><dd>Surface solar radiation downwards</dd><dt><span>original_variable :</span></dt><dd>ssrd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:13:31] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1603,13 +1603,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -1654,14 +1654,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -1674,7 +1674,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -1682,7 +1682,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1690,7 +1690,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -1706,7 +1706,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -1725,7 +1725,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -1741,16 +1741,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rss</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-8152ae4f-f2a8-45c5-9781-a0319189eb71' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8152ae4f-f2a8-45c5-9781-a0319189eb71' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-19886d2f-0110-4706-bd10-2ad8b9dc0e64' class='xr-var-data-in' type='checkbox'><label for='data-19886d2f-0110-4706-bd10-2ad8b9dc0e64' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth (both direct and diffuse) minus the amount reflected by the Earth&#x27;s surface (which is governed by the albedo)</dd><dt><span>original_long_name :</span></dt><dd>Surface net solar radiation</dd><dt><span>original_variable :</span></dt><dd>ssr</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:22:47] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rss</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-a4dbec81-af03-49fa-9fd3-bcc110147d94' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a4dbec81-af03-49fa-9fd3-bcc110147d94' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-af9337ea-a7b6-40cc-9776-a13f5b4f29fe' class='xr-var-data-in' type='checkbox'><label for='data-af9337ea-a7b6-40cc-9776-a13f5b4f29fe' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth (both direct and diffuse) minus the amount reflected by the Earth&#x27;s surface (which is governed by the albedo)</dd><dt><span>original_long_name :</span></dt><dd>Surface net solar radiation</dd><dt><span>original_variable :</span></dt><dd>ssr</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:22:47] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1765,13 +1765,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 140.35 GiB </td>\n",
+       "                        <td> 140.50 GiB </td>\n",
        "                        <td> 13.92 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 801, 1700) </td>\n",
+       "                        <td> (27698, 801, 1700) </td>\n",
        "                        <td> (365, 100, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -1816,14 +1816,14 @@
        "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"75\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"79\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"83\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"87\" />\n",
+       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"86\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"90\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"94\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"98\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"98\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.76611675622718 10.0,31.17788146210953\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,101.75944222482661 10.0,31.17120693070897\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"45\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -1836,7 +1836,7 @@
        "  <line x1=\"36\" y1=\"26\" x2=\"71\" y2=\"26\" />\n",
        "  <line x1=\"39\" y1=\"29\" x2=\"75\" y2=\"29\" />\n",
        "  <line x1=\"43\" y1=\"33\" x2=\"79\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"83\" y2=\"37\" />\n",
+       "  <line x1=\"47\" y1=\"37\" x2=\"82\" y2=\"37\" />\n",
        "  <line x1=\"50\" y1=\"40\" x2=\"86\" y2=\"40\" />\n",
        "  <line x1=\"54\" y1=\"44\" x2=\"90\" y2=\"44\" />\n",
        "  <line x1=\"58\" y1=\"48\" x2=\"94\" y2=\"48\" />\n",
@@ -1844,7 +1844,7 @@
        "  <line x1=\"65\" y1=\"55\" x2=\"101\" y2=\"55\" />\n",
        "  <line x1=\"69\" y1=\"59\" x2=\"105\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"109\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"112\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"112\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1852,7 +1852,7 @@
        "  <line x1=\"12\" y1=\"0\" x2=\"82\" y2=\"70\" />\n",
        "  <line x1=\"14\" y1=\"0\" x2=\"84\" y2=\"70\" />\n",
        "  <line x1=\"16\" y1=\"0\" x2=\"86\" y2=\"70\" />\n",
-       "  <line x1=\"18\" y1=\"0\" x2=\"89\" y2=\"70\" />\n",
+       "  <line x1=\"18\" y1=\"0\" x2=\"88\" y2=\"70\" />\n",
        "  <line x1=\"20\" y1=\"0\" x2=\"91\" y2=\"70\" />\n",
        "  <line x1=\"22\" y1=\"0\" x2=\"93\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"0\" x2=\"95\" y2=\"70\" />\n",
@@ -1868,7 +1868,7 @@
        "  <line x1=\"45\" y1=\"0\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 45.756689252531295,0.0 116.34492454664894,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 45.74991709833053,0.0 116.33815239244818,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"116\" y2=\"70\" style=\"stroke-width:2\" />\n",
@@ -1887,7 +1887,7 @@
        "  <line x1=\"82\" y1=\"70\" x2=\"82\" y2=\"101\" />\n",
        "  <line x1=\"84\" y1=\"70\" x2=\"84\" y2=\"101\" />\n",
        "  <line x1=\"86\" y1=\"70\" x2=\"86\" y2=\"101\" />\n",
-       "  <line x1=\"89\" y1=\"70\" x2=\"89\" y2=\"101\" />\n",
+       "  <line x1=\"88\" y1=\"70\" x2=\"88\" y2=\"101\" />\n",
        "  <line x1=\"91\" y1=\"70\" x2=\"91\" y2=\"101\" />\n",
        "  <line x1=\"93\" y1=\"70\" x2=\"93\" y2=\"101\" />\n",
        "  <line x1=\"95\" y1=\"70\" x2=\"95\" y2=\"101\" />\n",
@@ -1903,16 +1903,16 @@
        "  <line x1=\"116\" y1=\"70\" x2=\"116\" y2=\"101\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 116.34492454664894,70.58823529411765 116.34492454664894,101.76611675622718 80.58823529411765,101.76611675622718\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"80.58823529411765,70.58823529411765 116.33815239244818,70.58823529411765 116.33815239244818,101.75944222482661 80.58823529411765,101.75944222482661\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
-       "  <text x=\"98.466580\" y=\"121.766117\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
-       "  <text x=\"136.344925\" y=\"86.177176\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.344925,86.177176)\">801</text>\n",
-       "  <text x=\"35.294118\" y=\"86.471999\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.471999)\">27667</text>\n",
+       "  <text x=\"98.463194\" y=\"121.759442\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >1700</text>\n",
+       "  <text x=\"136.338152\" y=\"86.173839\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,136.338152,86.173839)\">801</text>\n",
+       "  <text x=\"35.294118\" y=\"86.465325\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,86.465325)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-adcd99d4-17da-4d54-b797-b91f7e840de5' class='xr-section-summary-in' type='checkbox'  ><label for='section-adcd99d4-17da-4d54-b797-b91f7e840de5' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-3da6d6d1-6be8-4f5c-ae7c-8b0d5bcf177a' class='xr-index-data-in' type='checkbox'/><label for='index-3da6d6d1-6be8-4f5c-ae7c-8b0d5bcf177a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([              10.0, 10.100000381469727, 10.199999809265137,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-f0457eab-6eec-460f-86b7-ed0b8e476f9e' class='xr-section-summary-in' type='checkbox'  ><label for='section-f0457eab-6eec-460f-86b7-ed0b8e476f9e' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-e43dd990-761a-4859-ac71-5af1bcfec375' class='xr-index-data-in' type='checkbox'/><label for='index-e43dd990-761a-4859-ac71-5af1bcfec375' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([              10.0, 10.100000381469727, 10.199999809265137,\n",
        "       10.300000190734863, 10.399999618530273,               10.5,\n",
        "       10.600000381469727, 10.699999809265137, 10.800000190734863,\n",
        "       10.899999618530273,\n",
@@ -1921,7 +1921,7 @@
        "         89.4000015258789,               89.5,   89.5999984741211,\n",
        "        89.69999694824219,  89.80000305175781,   89.9000015258789,\n",
        "                     90.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;lat&#x27;, length=801))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-14edfc84-99b3-4fe0-b1f6-c1a7c7493c44' class='xr-index-data-in' type='checkbox'/><label for='index-14edfc84-99b3-4fe0-b1f6-c1a7c7493c44' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-179.89999389648438,  -179.8000030517578,  -179.6999969482422,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;lat&#x27;, length=801))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-81fd9ef0-018f-4148-8a1c-0fc4a8729979' class='xr-index-data-in' type='checkbox'/><label for='index-81fd9ef0-018f-4148-8a1c-0fc4a8729979' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-179.89999389648438,  -179.8000030517578,  -179.6999969482422,\n",
        "       -179.60000610351562,              -179.5, -179.39999389648438,\n",
        "        -179.3000030517578,  -179.1999969482422, -179.10000610351562,\n",
        "                    -179.0,\n",
@@ -1930,22 +1930,22 @@
        "       -10.600000381469727,               -10.5, -10.399999618530273,\n",
        "       -10.300000190734863, -10.199999809265137, -10.100000381469727,\n",
        "                     -10.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;lon&#x27;, length=1700))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-aaaeea49-b815-48a0-ae2b-163841230000' class='xr-index-data-in' type='checkbox'/><label for='index-aaaeea49-b815-48a0-ae2b-163841230000' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1950-01-01&#x27;, &#x27;1950-01-02&#x27;, &#x27;1950-01-03&#x27;, &#x27;1950-01-04&#x27;,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;lon&#x27;, length=1700))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-268dc0f9-9c26-4578-a7d9-46c8024b29f4' class='xr-index-data-in' type='checkbox'/><label for='index-268dc0f9-9c26-4578-a7d9-46c8024b29f4' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1950-01-01&#x27;, &#x27;1950-01-02&#x27;, &#x27;1950-01-03&#x27;, &#x27;1950-01-04&#x27;,\n",
        "               &#x27;1950-01-05&#x27;, &#x27;1950-01-06&#x27;, &#x27;1950-01-07&#x27;, &#x27;1950-01-08&#x27;,\n",
        "               &#x27;1950-01-09&#x27;, &#x27;1950-01-10&#x27;,\n",
        "               ...\n",
-       "               &#x27;2025-09-21&#x27;, &#x27;2025-09-22&#x27;, &#x27;2025-09-23&#x27;, &#x27;2025-09-24&#x27;,\n",
-       "               &#x27;2025-09-25&#x27;, &#x27;2025-09-26&#x27;, &#x27;2025-09-27&#x27;, &#x27;2025-09-28&#x27;,\n",
-       "               &#x27;2025-09-29&#x27;, &#x27;2025-09-30&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=27667, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0bfad84a-7f23-4d16-8aba-c087956a8922' class='xr-section-summary-in' type='checkbox'  ><label for='section-0bfad84a-7f23-4d16-8aba-c087956a8922' class='xr-section-summary' >Attributes: <span>(27)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.9</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>doi :</span></dt><dd>https://doi.org/10.24381/cds.e2161bac</dd><dt><span>domain :</span></dt><dd>NAM</dd><dt><span>frequency :</span></dt><dd>day</dd><dt><span>history :</span></dt><dd>[2022-12-25 09:07:39.901698] Converted variables and modified metadata for CF-like compliance. 2022-06-14 22:47:32 GMT by grib_to_netcdf-2.24.3: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data0/adaptor.mars.internal-1655246820.5771172-15214-2-143cd489-ece2-4311-85e6-aa6a10567823.nc /cache/tmp/143cd489-ece2-4311-85e6-aa6a10567823-adaptor.mars.internal-1655246683.1830711-15214-3-tmp.grib</dd><dt><span>institution :</span></dt><dd>ECMWF</dd><dt><span>intake_esm_dataset_key :</span></dt><dd>ECMWF_ERA5-Land_NAM.NAM.raw.D</dd><dt><span>intake_esm_vars :</span></dt><dd>tas</dd><dt><span>license :</span></dt><dd>Please acknowledge the use of ERA5-Land as stated in the Copernicus C3S/CAMS License agreement http://apps.ecmwf.int/datasets/licences/copernicus/</dd><dt><span>license_type :</span></dt><dd>permissive</dd><dt><span>processing_level :</span></dt><dd>raw</dd><dt><span>project :</span></dt><dd>era5-land</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>source :</span></dt><dd>ERA5-Land</dd><dt><span>table_date :</span></dt><dd>2022-12-21</dd><dt><span>table_id :</span></dt><dd>ECMWF</dd><dt><span>type :</span></dt><dd>reanalysis</dd><dt><span>format :</span></dt><dd>netcdf</dd><dt><span>title :</span></dt><dd>ERA5-Land : daily</dd><dt><span>institute :</span></dt><dd>European Centre for Medium-Range Weather Forecasts</dd><dt><span>institute_id :</span></dt><dd>ECMWF</dd><dt><span>dataset_id :</span></dt><dd>ERA5-Land</dd><dt><span>abstract :</span></dt><dd>ERA5-Land provides hourly high resolution information of surface variables. The data is a replay of the land component of the ERA5 climate reanalysis with a finer spatial resolution: ~9km grid spacing. ERA5-Land includes information about uncertainties for all variables at reduced spatial and temporal resolutions. The model used in the production of ERA5-Land is the tiled ECMWF Scheme for Surface Exchanges over Land incorporating land surface hydrology (H-TESSEL).</dd><dt><span>dataset_description :</span></dt><dd>https://www.ecmwf.int/en/era5-land</dd><dt><span>attribution :</span></dt><dd>Contains modified Copernicus Climate Change Service Information 2022. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus Information or Data it contains.</dd><dt><span>citation :</span></dt><dd>Muñoz Sabater, J., (2021): ERA5-Land hourly data from 1950 to 1980. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (Accessed on 2022.06.07)</dd></dl></div></li></ul></div></div>"
+       "               &#x27;2025-10-22&#x27;, &#x27;2025-10-23&#x27;, &#x27;2025-10-24&#x27;, &#x27;2025-10-25&#x27;,\n",
+       "               &#x27;2025-10-26&#x27;, &#x27;2025-10-27&#x27;, &#x27;2025-10-28&#x27;, &#x27;2025-10-29&#x27;,\n",
+       "               &#x27;2025-10-30&#x27;, &#x27;2025-10-31&#x27;],\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=27698, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-85461337-4b3d-4619-861a-3c0429b01a3d' class='xr-section-summary-in' type='checkbox'  ><label for='section-85461337-4b3d-4619-861a-3c0429b01a3d' class='xr-section-summary' >Attributes: <span>(27)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.9</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>doi :</span></dt><dd>https://doi.org/10.24381/cds.e2161bac</dd><dt><span>domain :</span></dt><dd>NAM</dd><dt><span>frequency :</span></dt><dd>day</dd><dt><span>history :</span></dt><dd>[2022-12-25 09:07:39.901698] Converted variables and modified metadata for CF-like compliance. 2022-06-14 22:47:32 GMT by grib_to_netcdf-2.24.3: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data0/adaptor.mars.internal-1655246820.5771172-15214-2-143cd489-ece2-4311-85e6-aa6a10567823.nc /cache/tmp/143cd489-ece2-4311-85e6-aa6a10567823-adaptor.mars.internal-1655246683.1830711-15214-3-tmp.grib</dd><dt><span>institution :</span></dt><dd>ECMWF</dd><dt><span>intake_esm_dataset_key :</span></dt><dd>ECMWF_ERA5-Land_NAM.NAM.raw.D</dd><dt><span>intake_esm_vars :</span></dt><dd>tas</dd><dt><span>license :</span></dt><dd>Please acknowledge the use of ERA5-Land as stated in the Copernicus C3S/CAMS License agreement http://apps.ecmwf.int/datasets/licences/copernicus/</dd><dt><span>license_type :</span></dt><dd>permissive</dd><dt><span>processing_level :</span></dt><dd>raw</dd><dt><span>project :</span></dt><dd>era5-land</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>source :</span></dt><dd>ERA5-Land</dd><dt><span>table_date :</span></dt><dd>2022-12-21</dd><dt><span>table_id :</span></dt><dd>ECMWF</dd><dt><span>type :</span></dt><dd>reanalysis</dd><dt><span>format :</span></dt><dd>netcdf</dd><dt><span>title :</span></dt><dd>ERA5-Land : daily</dd><dt><span>institute :</span></dt><dd>European Centre for Medium-Range Weather Forecasts</dd><dt><span>institute_id :</span></dt><dd>ECMWF</dd><dt><span>dataset_id :</span></dt><dd>ERA5-Land</dd><dt><span>abstract :</span></dt><dd>ERA5-Land provides hourly high resolution information of surface variables. The data is a replay of the land component of the ERA5 climate reanalysis with a finer spatial resolution: ~9km grid spacing. ERA5-Land includes information about uncertainties for all variables at reduced spatial and temporal resolutions. The model used in the production of ERA5-Land is the tiled ECMWF Scheme for Surface Exchanges over Land incorporating land surface hydrology (H-TESSEL).</dd><dt><span>dataset_description :</span></dt><dd>https://www.ecmwf.int/en/era5-land</dd><dt><span>attribution :</span></dt><dd>Contains modified Copernicus Climate Change Service Information 2022. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus Information or Data it contains.</dd><dt><span>citation :</span></dt><dd>Muñoz Sabater, J., (2021): ERA5-Land hourly data from 1950 to 1980. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (Accessed on 2022.06.07)</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 1TB\n",
-       "Dimensions:  (lat: 801, lon: 1700, time: 27667)\n",
+       "Dimensions:  (lat: 801, lon: 1700, time: 27698)\n",
        "Coordinates:\n",
        "  * lat      (lat) float32 3kB 10.0 10.1 10.2 10.3 10.4 ... 89.7 89.8 89.9 90.0\n",
        "  * lon      (lon) float32 7kB -179.9 -179.8 -179.7 -179.6 ... -10.2 -10.1 -10.0\n",
-       "  * time     (time) datetime64[ns] 221kB 1950-01-01 1950-01-02 ... 2025-09-30\n",
+       "  * time     (time) datetime64[ns] 222kB 1950-01-01 1950-01-02 ... 2025-10-31\n",
        "Data variables:\n",
        "    tas      (time, lat, lon) float32 151GB dask.array<chunksize=(365, 100, 100), meta=np.ndarray>\n",
        "    tasmin   (time, lat, lon) float32 151GB dask.array<chunksize=(365, 100, 100), meta=np.ndarray>\n",
@@ -1980,7 +1980,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[                                        ] | 0% Completed | 518.13 us"
+      "[                                        ] | 0% Completed | 449.49 us"
      ]
     },
     {
@@ -1988,7 +1988,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[                                        ] | 0% Completed | 108.75 ms"
+      "[                                        ] | 0% Completed | 108.96 ms"
      ]
     },
     {
@@ -1996,7 +1996,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[                                        ] | 1% Completed | 210.55 ms"
+      "[                                        ] | 0% Completed | 210.87 ms"
      ]
     },
     {
@@ -2004,7 +2004,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#                                       ] | 3% Completed | 311.26 ms"
+      "[                                        ] | 0% Completed | 312.66 ms"
      ]
     },
     {
@@ -2012,7 +2012,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#                                       ] | 3% Completed | 412.21 ms"
+      "[                                        ] | 1% Completed | 414.34 ms"
      ]
     },
     {
@@ -2020,7 +2020,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##                                      ] | 5% Completed | 514.16 ms"
+      "[                                        ] | 1% Completed | 515.46 ms"
      ]
     },
     {
@@ -2028,7 +2028,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##                                      ] | 6% Completed | 615.22 ms"
+      "[#                                       ] | 2% Completed | 616.93 ms"
      ]
     },
     {
@@ -2036,7 +2036,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###                                     ] | 7% Completed | 716.90 ms"
+      "[#                                       ] | 3% Completed | 718.00 ms"
      ]
     },
     {
@@ -2044,7 +2044,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###                                     ] | 9% Completed | 819.11 ms"
+      "[#                                       ] | 3% Completed | 819.85 ms"
      ]
     },
     {
@@ -2052,7 +2052,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####                                    ] | 10% Completed | 921.60 ms"
+      "[#                                       ] | 4% Completed | 920.88 ms"
      ]
     },
     {
@@ -2060,7 +2060,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####                                    ] | 11% Completed | 1.02 s"
+      "[##                                      ] | 5% Completed | 1.02 s"
      ]
     },
     {
@@ -2068,7 +2068,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####                                    ] | 11% Completed | 1.12 s"
+      "[##                                      ] | 6% Completed | 1.12 s"
      ]
     },
     {
@@ -2076,7 +2076,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####                                    ] | 11% Completed | 1.23 s"
+      "[##                                      ] | 7% Completed | 1.22 s"
      ]
     },
     {
@@ -2084,7 +2084,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####                                    ] | 12% Completed | 1.33 s"
+      "[###                                     ] | 8% Completed | 1.33 s"
      ]
     },
     {
@@ -2092,7 +2092,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####                                   ] | 13% Completed | 1.43 s"
+      "[###                                     ] | 9% Completed | 1.43 s"
      ]
     },
     {
@@ -2100,7 +2100,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####                                   ] | 13% Completed | 1.53 s"
+      "[###                                     ] | 9% Completed | 1.53 s"
      ]
     },
     {
@@ -2108,7 +2108,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####                                   ] | 13% Completed | 1.63 s"
+      "[###                                     ] | 9% Completed | 1.63 s"
      ]
     },
     {
@@ -2116,7 +2116,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####                                   ] | 14% Completed | 1.73 s"
+      "[####                                    ] | 10% Completed | 1.73 s"
      ]
     },
     {
@@ -2124,7 +2124,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####                                   ] | 14% Completed | 1.83 s"
+      "[####                                    ] | 11% Completed | 1.83 s"
      ]
     },
     {
@@ -2132,7 +2132,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######                                  ] | 15% Completed | 1.93 s"
+      "[####                                    ] | 11% Completed | 1.93 s"
      ]
     },
     {
@@ -2140,7 +2140,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######                                  ] | 16% Completed | 2.04 s"
+      "[####                                    ] | 11% Completed | 2.04 s"
      ]
     },
     {
@@ -2148,7 +2148,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######                                  ] | 16% Completed | 2.14 s"
+      "[####                                    ] | 11% Completed | 2.14 s"
      ]
     },
     {
@@ -2156,7 +2156,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######                                  ] | 16% Completed | 2.24 s"
+      "[####                                    ] | 12% Completed | 2.24 s"
      ]
     },
     {
@@ -2164,7 +2164,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 17% Completed | 2.34 s"
+      "[#####                                   ] | 13% Completed | 2.34 s"
      ]
     },
     {
@@ -2172,7 +2172,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 17% Completed | 2.44 s"
+      "[#####                                   ] | 13% Completed | 2.44 s"
      ]
     },
     {
@@ -2180,7 +2180,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 18% Completed | 2.54 s"
+      "[#####                                   ] | 13% Completed | 2.54 s"
      ]
     },
     {
@@ -2188,7 +2188,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 18% Completed | 2.64 s"
+      "[#####                                   ] | 14% Completed | 2.65 s"
      ]
     },
     {
@@ -2196,7 +2196,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 18% Completed | 2.75 s"
+      "[#####                                   ] | 14% Completed | 2.75 s"
      ]
     },
     {
@@ -2204,7 +2204,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 18% Completed | 2.85 s"
+      "[#####                                   ] | 14% Completed | 2.85 s"
      ]
     },
     {
@@ -2212,7 +2212,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 19% Completed | 2.95 s"
+      "[######                                  ] | 15% Completed | 2.95 s"
      ]
     },
     {
@@ -2220,7 +2220,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######                                 ] | 19% Completed | 3.05 s"
+      "[######                                  ] | 15% Completed | 3.05 s"
      ]
     },
     {
@@ -2228,7 +2228,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 20% Completed | 3.15 s"
+      "[######                                  ] | 16% Completed | 3.15 s"
      ]
     },
     {
@@ -2236,7 +2236,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 20% Completed | 3.25 s"
+      "[######                                  ] | 16% Completed | 3.25 s"
      ]
     },
     {
@@ -2244,7 +2244,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 20% Completed | 3.36 s"
+      "[######                                  ] | 16% Completed | 3.36 s"
      ]
     },
     {
@@ -2252,7 +2252,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 21% Completed | 3.46 s"
+      "[######                                  ] | 16% Completed | 3.46 s"
      ]
     },
     {
@@ -2260,7 +2260,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 22% Completed | 3.56 s"
+      "[######                                  ] | 16% Completed | 3.56 s"
      ]
     },
     {
@@ -2268,7 +2268,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 22% Completed | 3.66 s"
+      "[#######                                 ] | 17% Completed | 3.66 s"
      ]
     },
     {
@@ -2276,7 +2276,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 22% Completed | 3.76 s"
+      "[#######                                 ] | 17% Completed | 3.76 s"
      ]
     },
     {
@@ -2284,7 +2284,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########                                ] | 22% Completed | 3.86 s"
+      "[#######                                 ] | 18% Completed | 3.86 s"
      ]
     },
     {
@@ -2292,7 +2292,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 22% Completed | 3.96 s"
+      "[#######                                 ] | 18% Completed | 3.96 s"
      ]
     },
     {
@@ -2300,7 +2300,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 22% Completed | 4.07 s"
+      "[#######                                 ] | 18% Completed | 4.06 s"
      ]
     },
     {
@@ -2308,7 +2308,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 23% Completed | 4.17 s"
+      "[#######                                 ] | 18% Completed | 4.17 s"
      ]
     },
     {
@@ -2316,7 +2316,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 23% Completed | 4.27 s"
+      "[#######                                 ] | 18% Completed | 4.27 s"
      ]
     },
     {
@@ -2324,7 +2324,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 23% Completed | 4.37 s"
+      "[#######                                 ] | 18% Completed | 4.37 s"
      ]
     },
     {
@@ -2332,7 +2332,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 24% Completed | 4.47 s"
+      "[#######                                 ] | 18% Completed | 4.47 s"
      ]
     },
     {
@@ -2340,7 +2340,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 24% Completed | 4.57 s"
+      "[#######                                 ] | 18% Completed | 4.57 s"
      ]
     },
     {
@@ -2348,7 +2348,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 24% Completed | 4.68 s"
+      "[#######                                 ] | 19% Completed | 4.67 s"
      ]
     },
     {
@@ -2356,7 +2356,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########                               ] | 24% Completed | 4.78 s"
+      "[#######                                 ] | 19% Completed | 4.77 s"
      ]
     },
     {
@@ -2364,7 +2364,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########                              ] | 25% Completed | 4.88 s"
+      "[########                                ] | 20% Completed | 4.88 s"
      ]
     },
     {
@@ -2372,7 +2372,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########                              ] | 26% Completed | 4.98 s"
+      "[########                                ] | 20% Completed | 4.98 s"
      ]
     },
     {
@@ -2380,7 +2380,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########                              ] | 26% Completed | 5.08 s"
+      "[########                                ] | 20% Completed | 5.08 s"
      ]
     },
     {
@@ -2388,7 +2388,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########                              ] | 27% Completed | 5.18 s"
+      "[########                                ] | 20% Completed | 5.18 s"
      ]
     },
     {
@@ -2396,7 +2396,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########                              ] | 27% Completed | 5.28 s"
+      "[########                                ] | 20% Completed | 5.28 s"
      ]
     },
     {
@@ -2404,7 +2404,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.39 s"
+      "[########                                ] | 21% Completed | 5.38 s"
      ]
     },
     {
@@ -2412,7 +2412,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.49 s"
+      "[########                                ] | 22% Completed | 5.49 s"
      ]
     },
     {
@@ -2420,7 +2420,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.59 s"
+      "[########                                ] | 22% Completed | 5.59 s"
      ]
     },
     {
@@ -2428,7 +2428,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.69 s"
+      "[########                                ] | 22% Completed | 5.69 s"
      ]
     },
     {
@@ -2436,7 +2436,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.79 s"
+      "[########                                ] | 22% Completed | 5.79 s"
      ]
     },
     {
@@ -2444,7 +2444,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.89 s"
+      "[#########                               ] | 22% Completed | 5.89 s"
      ]
     },
     {
@@ -2452,7 +2452,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 5.99 s"
+      "[#########                               ] | 22% Completed | 5.99 s"
      ]
     },
     {
@@ -2460,7 +2460,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 28% Completed | 6.09 s"
+      "[#########                               ] | 22% Completed | 6.10 s"
      ]
     },
     {
@@ -2468,7 +2468,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.20 s"
+      "[#########                               ] | 23% Completed | 6.20 s"
      ]
     },
     {
@@ -2476,7 +2476,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.30 s"
+      "[#########                               ] | 23% Completed | 6.30 s"
      ]
     },
     {
@@ -2484,7 +2484,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.40 s"
+      "[#########                               ] | 23% Completed | 6.40 s"
      ]
     },
     {
@@ -2492,7 +2492,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.50 s"
+      "[#########                               ] | 24% Completed | 6.50 s"
      ]
     },
     {
@@ -2500,7 +2500,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.60 s"
+      "[#########                               ] | 24% Completed | 6.60 s"
      ]
     },
     {
@@ -2508,7 +2508,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.70 s"
+      "[#########                               ] | 24% Completed | 6.71 s"
      ]
     },
     {
@@ -2516,7 +2516,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.81 s"
+      "[#########                               ] | 24% Completed | 6.81 s"
      ]
     },
     {
@@ -2524,7 +2524,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########                             ] | 29% Completed | 6.91 s"
+      "[#########                               ] | 24% Completed | 6.91 s"
      ]
     },
     {
@@ -2532,7 +2532,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 30% Completed | 7.01 s"
+      "[##########                              ] | 25% Completed | 7.01 s"
      ]
     },
     {
@@ -2540,7 +2540,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 30% Completed | 7.11 s"
+      "[##########                              ] | 25% Completed | 7.11 s"
      ]
     },
     {
@@ -2548,7 +2548,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 30% Completed | 7.21 s"
+      "[##########                              ] | 26% Completed | 7.21 s"
      ]
     },
     {
@@ -2556,7 +2556,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 31% Completed | 7.31 s"
+      "[##########                              ] | 26% Completed | 7.32 s"
      ]
     },
     {
@@ -2564,7 +2564,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 31% Completed | 7.42 s"
+      "[##########                              ] | 26% Completed | 7.42 s"
      ]
     },
     {
@@ -2572,7 +2572,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 31% Completed | 7.52 s"
+      "[##########                              ] | 27% Completed | 7.52 s"
      ]
     },
     {
@@ -2580,7 +2580,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############                            ] | 31% Completed | 7.62 s"
+      "[##########                              ] | 27% Completed | 7.62 s"
      ]
     },
     {
@@ -2588,7 +2588,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 32% Completed | 7.72 s"
+      "[##########                              ] | 27% Completed | 7.72 s"
      ]
     },
     {
@@ -2596,7 +2596,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 33% Completed | 7.83 s"
+      "[###########                             ] | 28% Completed | 7.82 s"
      ]
     },
     {
@@ -2604,7 +2604,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 33% Completed | 7.93 s"
+      "[###########                             ] | 28% Completed | 7.93 s"
      ]
     },
     {
@@ -2612,7 +2612,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 33% Completed | 8.03 s"
+      "[###########                             ] | 28% Completed | 8.03 s"
      ]
     },
     {
@@ -2620,7 +2620,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 33% Completed | 8.13 s"
+      "[###########                             ] | 28% Completed | 8.13 s"
      ]
     },
     {
@@ -2628,7 +2628,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 33% Completed | 8.23 s"
+      "[###########                             ] | 28% Completed | 8.23 s"
      ]
     },
     {
@@ -2636,7 +2636,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 33% Completed | 8.33 s"
+      "[###########                             ] | 28% Completed | 8.33 s"
      ]
     },
     {
@@ -2644,7 +2644,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 34% Completed | 8.44 s"
+      "[###########                             ] | 28% Completed | 8.43 s"
      ]
     },
     {
@@ -2652,7 +2652,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 34% Completed | 8.54 s"
+      "[###########                             ] | 28% Completed | 8.53 s"
      ]
     },
     {
@@ -2660,7 +2660,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 34% Completed | 8.64 s"
+      "[###########                             ] | 28% Completed | 8.64 s"
      ]
     },
     {
@@ -2668,7 +2668,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############                           ] | 34% Completed | 8.74 s"
+      "[###########                             ] | 28% Completed | 8.74 s"
      ]
     },
     {
@@ -2676,7 +2676,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 8.84 s"
+      "[###########                             ] | 29% Completed | 8.84 s"
      ]
     },
     {
@@ -2684,7 +2684,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 8.94 s"
+      "[###########                             ] | 29% Completed | 8.94 s"
      ]
     },
     {
@@ -2692,7 +2692,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 9.05 s"
+      "[###########                             ] | 29% Completed | 9.04 s"
      ]
     },
     {
@@ -2700,7 +2700,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 9.15 s"
+      "[###########                             ] | 29% Completed | 9.14 s"
      ]
     },
     {
@@ -2708,7 +2708,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 9.25 s"
+      "[###########                             ] | 29% Completed | 9.25 s"
      ]
     },
     {
@@ -2716,7 +2716,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 9.35 s"
+      "[###########                             ] | 29% Completed | 9.35 s"
      ]
     },
     {
@@ -2724,7 +2724,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 9.45 s"
+      "[###########                             ] | 29% Completed | 9.45 s"
      ]
     },
     {
@@ -2732,7 +2732,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 35% Completed | 9.56 s"
+      "[###########                             ] | 29% Completed | 9.55 s"
      ]
     },
     {
@@ -2740,7 +2740,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 36% Completed | 9.66 s"
+      "[###########                             ] | 29% Completed | 9.65 s"
      ]
     },
     {
@@ -2748,7 +2748,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 36% Completed | 9.76 s"
+      "[############                            ] | 30% Completed | 9.76 s"
      ]
     },
     {
@@ -2756,7 +2756,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 36% Completed | 9.86 s"
+      "[############                            ] | 30% Completed | 9.86 s"
      ]
     },
     {
@@ -2764,7 +2764,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 36% Completed | 9.96 s"
+      "[############                            ] | 30% Completed | 9.96 s"
      ]
     },
     {
@@ -2772,7 +2772,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 37% Completed | 10.06 s"
+      "[############                            ] | 31% Completed | 10.06 s"
      ]
     },
     {
@@ -2780,7 +2780,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 37% Completed | 10.17 s"
+      "[############                            ] | 31% Completed | 10.16 s"
      ]
     },
     {
@@ -2788,7 +2788,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 37% Completed | 10.27 s"
+      "[############                            ] | 31% Completed | 10.26 s"
      ]
     },
     {
@@ -2796,7 +2796,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############                          ] | 37% Completed | 10.37 s"
+      "[############                            ] | 31% Completed | 10.36 s"
      ]
     },
     {
@@ -2804,7 +2804,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 37% Completed | 10.47 s"
+      "[#############                           ] | 32% Completed | 10.46 s"
      ]
     },
     {
@@ -2812,7 +2812,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 37% Completed | 10.57 s"
+      "[#############                           ] | 32% Completed | 10.57 s"
      ]
     },
     {
@@ -2820,7 +2820,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 37% Completed | 10.67 s"
+      "[#############                           ] | 33% Completed | 10.67 s"
      ]
     },
     {
@@ -2828,7 +2828,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 37% Completed | 10.78 s"
+      "[#############                           ] | 33% Completed | 10.77 s"
      ]
     },
     {
@@ -2836,7 +2836,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 37% Completed | 10.88 s"
+      "[#############                           ] | 33% Completed | 10.87 s"
      ]
     },
     {
@@ -2844,7 +2844,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 38% Completed | 10.98 s"
+      "[#############                           ] | 33% Completed | 10.97 s"
      ]
     },
     {
@@ -2852,7 +2852,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 39% Completed | 11.08 s"
+      "[#############                           ] | 33% Completed | 11.07 s"
      ]
     },
     {
@@ -2860,7 +2860,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 39% Completed | 11.18 s"
+      "[#############                           ] | 33% Completed | 11.17 s"
      ]
     },
     {
@@ -2868,7 +2868,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 39% Completed | 11.28 s"
+      "[#############                           ] | 33% Completed | 11.27 s"
      ]
     },
     {
@@ -2876,7 +2876,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############                         ] | 39% Completed | 11.39 s"
+      "[#############                           ] | 34% Completed | 11.37 s"
      ]
     },
     {
@@ -2884,7 +2884,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 40% Completed | 11.49 s"
+      "[#############                           ] | 34% Completed | 11.48 s"
      ]
     },
     {
@@ -2892,7 +2892,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 40% Completed | 11.59 s"
+      "[#############                           ] | 34% Completed | 11.58 s"
      ]
     },
     {
@@ -2900,7 +2900,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 40% Completed | 11.69 s"
+      "[#############                           ] | 34% Completed | 11.68 s"
      ]
     },
     {
@@ -2908,7 +2908,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 40% Completed | 11.79 s"
+      "[##############                          ] | 35% Completed | 11.78 s"
      ]
     },
     {
@@ -2916,7 +2916,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 41% Completed | 11.89 s"
+      "[##############                          ] | 35% Completed | 11.88 s"
      ]
     },
     {
@@ -2924,7 +2924,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 41% Completed | 12.00 s"
+      "[##############                          ] | 35% Completed | 11.98 s"
      ]
     },
     {
@@ -2932,7 +2932,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 41% Completed | 12.10 s"
+      "[##############                          ] | 35% Completed | 12.09 s"
      ]
     },
     {
@@ -2940,7 +2940,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 41% Completed | 12.20 s"
+      "[##############                          ] | 35% Completed | 12.19 s"
      ]
     },
     {
@@ -2948,7 +2948,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 41% Completed | 12.30 s"
+      "[##############                          ] | 35% Completed | 12.29 s"
      ]
     },
     {
@@ -2956,7 +2956,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 42% Completed | 12.40 s"
+      "[##############                          ] | 35% Completed | 12.39 s"
      ]
     },
     {
@@ -2964,7 +2964,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 42% Completed | 12.50 s"
+      "[##############                          ] | 35% Completed | 12.50 s"
      ]
     },
     {
@@ -2972,7 +2972,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################                        ] | 42% Completed | 12.61 s"
+      "[##############                          ] | 35% Completed | 12.60 s"
      ]
     },
     {
@@ -2980,7 +2980,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 42% Completed | 12.71 s"
+      "[##############                          ] | 36% Completed | 12.70 s"
      ]
     },
     {
@@ -2988,7 +2988,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 42% Completed | 12.81 s"
+      "[##############                          ] | 36% Completed | 12.80 s"
      ]
     },
     {
@@ -2996,7 +2996,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 42% Completed | 12.91 s"
+      "[##############                          ] | 36% Completed | 12.90 s"
      ]
     },
     {
@@ -3004,7 +3004,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 43% Completed | 13.01 s"
+      "[##############                          ] | 36% Completed | 13.00 s"
      ]
     },
     {
@@ -3012,7 +3012,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 43% Completed | 13.11 s"
+      "[##############                          ] | 37% Completed | 13.10 s"
      ]
     },
     {
@@ -3020,7 +3020,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.22 s"
+      "[##############                          ] | 37% Completed | 13.21 s"
      ]
     },
     {
@@ -3028,7 +3028,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.32 s"
+      "[##############                          ] | 37% Completed | 13.31 s"
      ]
     },
     {
@@ -3036,7 +3036,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.42 s"
+      "[##############                          ] | 37% Completed | 13.41 s"
      ]
     },
     {
@@ -3044,7 +3044,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.52 s"
+      "[##############                          ] | 37% Completed | 13.51 s"
      ]
     },
     {
@@ -3052,7 +3052,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.62 s"
+      "[###############                         ] | 37% Completed | 13.61 s"
      ]
     },
     {
@@ -3060,7 +3060,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.72 s"
+      "[###############                         ] | 37% Completed | 13.71 s"
      ]
     },
     {
@@ -3068,7 +3068,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.83 s"
+      "[###############                         ] | 37% Completed | 13.82 s"
      ]
     },
     {
@@ -3076,7 +3076,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################                       ] | 44% Completed | 13.93 s"
+      "[###############                         ] | 37% Completed | 13.92 s"
      ]
     },
     {
@@ -3084,7 +3084,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 45% Completed | 14.03 s"
+      "[###############                         ] | 38% Completed | 14.02 s"
      ]
     },
     {
@@ -3092,7 +3092,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 45% Completed | 14.13 s"
+      "[###############                         ] | 38% Completed | 14.12 s"
      ]
     },
     {
@@ -3100,7 +3100,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 45% Completed | 14.23 s"
+      "[###############                         ] | 38% Completed | 14.22 s"
      ]
     },
     {
@@ -3108,7 +3108,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 45% Completed | 14.33 s"
+      "[###############                         ] | 39% Completed | 14.32 s"
      ]
     },
     {
@@ -3116,7 +3116,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 45% Completed | 14.43 s"
+      "[###############                         ] | 39% Completed | 14.42 s"
      ]
     },
     {
@@ -3124,7 +3124,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 14.54 s"
+      "[###############                         ] | 39% Completed | 14.53 s"
      ]
     },
     {
@@ -3132,7 +3132,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 14.64 s"
+      "[###############                         ] | 39% Completed | 14.63 s"
      ]
     },
     {
@@ -3140,7 +3140,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 14.74 s"
+      "[###############                         ] | 39% Completed | 14.73 s"
      ]
     },
     {
@@ -3148,7 +3148,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 14.84 s"
+      "[################                        ] | 40% Completed | 14.83 s"
      ]
     },
     {
@@ -3156,7 +3156,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 14.94 s"
+      "[################                        ] | 40% Completed | 14.93 s"
      ]
     },
     {
@@ -3164,7 +3164,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 15.04 s"
+      "[################                        ] | 40% Completed | 15.03 s"
      ]
     },
     {
@@ -3172,7 +3172,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 15.14 s"
+      "[################                        ] | 40% Completed | 15.13 s"
      ]
     },
     {
@@ -3180,7 +3180,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 15.24 s"
+      "[################                        ] | 41% Completed | 15.24 s"
      ]
     },
     {
@@ -3188,7 +3188,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 15.35 s"
+      "[################                        ] | 41% Completed | 15.34 s"
      ]
     },
     {
@@ -3196,7 +3196,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 15.45 s"
+      "[################                        ] | 41% Completed | 15.44 s"
      ]
     },
     {
@@ -3204,7 +3204,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 46% Completed | 15.55 s"
+      "[################                        ] | 41% Completed | 15.54 s"
      ]
     },
     {
@@ -3212,7 +3212,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################                      ] | 47% Completed | 15.65 s"
+      "[################                        ] | 41% Completed | 15.64 s"
      ]
     },
     {
@@ -3220,7 +3220,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 47% Completed | 15.75 s"
+      "[################                        ] | 42% Completed | 15.74 s"
      ]
     },
     {
@@ -3228,7 +3228,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 47% Completed | 15.85 s"
+      "[################                        ] | 42% Completed | 15.84 s"
      ]
     },
     {
@@ -3236,7 +3236,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 47% Completed | 15.95 s"
+      "[################                        ] | 42% Completed | 15.95 s"
      ]
     },
     {
@@ -3244,7 +3244,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 48% Completed | 16.06 s"
+      "[#################                       ] | 42% Completed | 16.05 s"
      ]
     },
     {
@@ -3252,7 +3252,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 48% Completed | 16.16 s"
+      "[#################                       ] | 42% Completed | 16.15 s"
      ]
     },
     {
@@ -3260,7 +3260,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 48% Completed | 16.26 s"
+      "[#################                       ] | 42% Completed | 16.25 s"
      ]
     },
     {
@@ -3268,7 +3268,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################                     ] | 49% Completed | 16.36 s"
+      "[#################                       ] | 42% Completed | 16.35 s"
      ]
     },
     {
@@ -3276,7 +3276,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################                    ] | 50% Completed | 16.47 s"
+      "[#################                       ] | 43% Completed | 16.45 s"
      ]
     },
     {
@@ -3284,7 +3284,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################                    ] | 50% Completed | 16.57 s"
+      "[#################                       ] | 43% Completed | 16.55 s"
      ]
     },
     {
@@ -3292,7 +3292,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################                    ] | 51% Completed | 16.67 s"
+      "[#################                       ] | 43% Completed | 16.65 s"
      ]
     },
     {
@@ -3300,7 +3300,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################                    ] | 52% Completed | 16.77 s"
+      "[#################                       ] | 44% Completed | 16.76 s"
      ]
     },
     {
@@ -3308,7 +3308,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################                    ] | 52% Completed | 16.87 s"
+      "[#################                       ] | 44% Completed | 16.86 s"
      ]
     },
     {
@@ -3316,7 +3316,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 52% Completed | 16.97 s"
+      "[#################                       ] | 44% Completed | 16.96 s"
      ]
     },
     {
@@ -3324,7 +3324,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 52% Completed | 17.07 s"
+      "[#################                       ] | 44% Completed | 17.06 s"
      ]
     },
     {
@@ -3332,7 +3332,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 52% Completed | 17.18 s"
+      "[#################                       ] | 44% Completed | 17.16 s"
      ]
     },
     {
@@ -3340,7 +3340,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 52% Completed | 17.28 s"
+      "[#################                       ] | 44% Completed | 17.26 s"
      ]
     },
     {
@@ -3348,7 +3348,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 53% Completed | 17.38 s"
+      "[#################                       ] | 44% Completed | 17.36 s"
      ]
     },
     {
@@ -3356,7 +3356,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 53% Completed | 17.48 s"
+      "[##################                      ] | 45% Completed | 17.47 s"
      ]
     },
     {
@@ -3364,7 +3364,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 53% Completed | 17.58 s"
+      "[##################                      ] | 45% Completed | 17.57 s"
      ]
     },
     {
@@ -3372,7 +3372,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 53% Completed | 17.69 s"
+      "[##################                      ] | 45% Completed | 17.67 s"
      ]
     },
     {
@@ -3380,7 +3380,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 54% Completed | 17.79 s"
+      "[##################                      ] | 45% Completed | 17.77 s"
      ]
     },
     {
@@ -3388,7 +3388,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################                   ] | 54% Completed | 17.89 s"
+      "[##################                      ] | 45% Completed | 17.87 s"
      ]
     },
     {
@@ -3396,7 +3396,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 55% Completed | 17.99 s"
+      "[##################                      ] | 45% Completed | 17.97 s"
      ]
     },
     {
@@ -3404,7 +3404,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 55% Completed | 18.09 s"
+      "[##################                      ] | 46% Completed | 18.07 s"
      ]
     },
     {
@@ -3412,7 +3412,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 55% Completed | 18.19 s"
+      "[##################                      ] | 46% Completed | 18.17 s"
      ]
     },
     {
@@ -3420,7 +3420,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 55% Completed | 18.29 s"
+      "[##################                      ] | 46% Completed | 18.27 s"
      ]
     },
     {
@@ -3428,7 +3428,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 18.40 s"
+      "[##################                      ] | 46% Completed | 18.37 s"
      ]
     },
     {
@@ -3436,7 +3436,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 18.50 s"
+      "[##################                      ] | 46% Completed | 18.48 s"
      ]
     },
     {
@@ -3444,7 +3444,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 18.60 s"
+      "[##################                      ] | 46% Completed | 18.58 s"
      ]
     },
     {
@@ -3452,7 +3452,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 18.70 s"
+      "[##################                      ] | 46% Completed | 18.68 s"
      ]
     },
     {
@@ -3460,7 +3460,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 18.80 s"
+      "[##################                      ] | 46% Completed | 18.78 s"
      ]
     },
     {
@@ -3468,7 +3468,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 18.90 s"
+      "[##################                      ] | 46% Completed | 18.88 s"
      ]
     },
     {
@@ -3476,7 +3476,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 19.01 s"
+      "[###################                     ] | 47% Completed | 18.98 s"
      ]
     },
     {
@@ -3484,7 +3484,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 19.11 s"
+      "[###################                     ] | 47% Completed | 19.08 s"
      ]
     },
     {
@@ -3492,7 +3492,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 56% Completed | 19.21 s"
+      "[###################                     ] | 47% Completed | 19.19 s"
      ]
     },
     {
@@ -3500,7 +3500,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 57% Completed | 19.31 s"
+      "[###################                     ] | 48% Completed | 19.29 s"
      ]
     },
     {
@@ -3508,7 +3508,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 57% Completed | 19.41 s"
+      "[###################                     ] | 48% Completed | 19.39 s"
      ]
     },
     {
@@ -3516,7 +3516,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 57% Completed | 19.52 s"
+      "[###################                     ] | 48% Completed | 19.49 s"
      ]
     },
     {
@@ -3524,7 +3524,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 57% Completed | 19.62 s"
+      "[###################                     ] | 48% Completed | 19.59 s"
      ]
     },
     {
@@ -3532,7 +3532,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################                  ] | 57% Completed | 19.72 s"
+      "[###################                     ] | 49% Completed | 19.69 s"
      ]
     },
     {
@@ -3540,7 +3540,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######################                 ] | 57% Completed | 19.82 s"
+      "[###################                     ] | 49% Completed | 19.79 s"
      ]
     },
     {
@@ -3548,7 +3548,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######################                 ] | 57% Completed | 19.92 s"
+      "[####################                    ] | 50% Completed | 19.90 s"
      ]
     },
     {
@@ -3556,7 +3556,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######################                 ] | 57% Completed | 20.02 s"
+      "[####################                    ] | 50% Completed | 20.00 s"
      ]
     },
     {
@@ -3564,7 +3564,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######################                 ] | 58% Completed | 20.12 s"
+      "[####################                    ] | 50% Completed | 20.10 s"
      ]
     },
     {
@@ -3572,7 +3572,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######################                 ] | 59% Completed | 20.23 s"
+      "[####################                    ] | 51% Completed | 20.20 s"
      ]
     },
     {
@@ -3580,7 +3580,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#######################                 ] | 59% Completed | 20.33 s"
+      "[####################                    ] | 52% Completed | 20.30 s"
      ]
     },
     {
@@ -3588,7 +3588,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########################                ] | 60% Completed | 20.43 s"
+      "[####################                    ] | 52% Completed | 20.40 s"
      ]
     },
     {
@@ -3596,7 +3596,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########################                ] | 60% Completed | 20.53 s"
+      "[#####################                   ] | 52% Completed | 20.51 s"
      ]
     },
     {
@@ -3604,7 +3604,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########################                ] | 61% Completed | 20.63 s"
+      "[#####################                   ] | 52% Completed | 20.61 s"
      ]
     },
     {
@@ -3612,7 +3612,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########################                ] | 61% Completed | 20.74 s"
+      "[#####################                   ] | 52% Completed | 20.71 s"
      ]
     },
     {
@@ -3620,7 +3620,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 62% Completed | 20.84 s"
+      "[#####################                   ] | 52% Completed | 20.81 s"
      ]
     },
     {
@@ -3628,7 +3628,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 63% Completed | 20.94 s"
+      "[#####################                   ] | 52% Completed | 20.91 s"
      ]
     },
     {
@@ -3636,7 +3636,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 63% Completed | 21.04 s"
+      "[#####################                   ] | 53% Completed | 21.02 s"
      ]
     },
     {
@@ -3644,7 +3644,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 63% Completed | 21.14 s"
+      "[#####################                   ] | 53% Completed | 21.12 s"
      ]
     },
     {
@@ -3652,7 +3652,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 63% Completed | 21.24 s"
+      "[#####################                   ] | 53% Completed | 21.22 s"
      ]
     },
     {
@@ -3660,7 +3660,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 64% Completed | 21.35 s"
+      "[#####################                   ] | 53% Completed | 21.32 s"
      ]
     },
     {
@@ -3668,7 +3668,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 64% Completed | 21.45 s"
+      "[#####################                   ] | 53% Completed | 21.42 s"
      ]
     },
     {
@@ -3676,7 +3676,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 64% Completed | 21.55 s"
+      "[#####################                   ] | 54% Completed | 21.52 s"
      ]
     },
     {
@@ -3684,7 +3684,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#########################               ] | 64% Completed | 21.65 s"
+      "[#####################                   ] | 54% Completed | 21.63 s"
      ]
     },
     {
@@ -3692,7 +3692,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 65% Completed | 21.75 s"
+      "[#####################                   ] | 54% Completed | 21.73 s"
      ]
     },
     {
@@ -3700,7 +3700,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 65% Completed | 21.86 s"
+      "[######################                  ] | 55% Completed | 21.83 s"
      ]
     },
     {
@@ -3708,7 +3708,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 65% Completed | 21.96 s"
+      "[######################                  ] | 55% Completed | 21.93 s"
      ]
     },
     {
@@ -3716,7 +3716,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 66% Completed | 22.06 s"
+      "[######################                  ] | 55% Completed | 22.03 s"
      ]
     },
     {
@@ -3724,7 +3724,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 66% Completed | 22.16 s"
+      "[######################                  ] | 55% Completed | 22.13 s"
      ]
     },
     {
@@ -3732,7 +3732,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 66% Completed | 22.26 s"
+      "[######################                  ] | 55% Completed | 22.23 s"
      ]
     },
     {
@@ -3740,7 +3740,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 66% Completed | 22.36 s"
+      "[######################                  ] | 56% Completed | 22.34 s"
      ]
     },
     {
@@ -3748,7 +3748,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 67% Completed | 22.47 s"
+      "[######################                  ] | 56% Completed | 22.44 s"
      ]
     },
     {
@@ -3756,7 +3756,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 67% Completed | 22.57 s"
+      "[######################                  ] | 56% Completed | 22.54 s"
      ]
     },
     {
@@ -3764,7 +3764,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 67% Completed | 22.67 s"
+      "[######################                  ] | 56% Completed | 22.64 s"
      ]
     },
     {
@@ -3772,7 +3772,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 67% Completed | 22.77 s"
+      "[######################                  ] | 56% Completed | 22.74 s"
      ]
     },
     {
@@ -3780,7 +3780,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##########################              ] | 67% Completed | 22.87 s"
+      "[######################                  ] | 56% Completed | 22.84 s"
      ]
     },
     {
@@ -3788,7 +3788,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 67% Completed | 22.97 s"
+      "[######################                  ] | 56% Completed | 22.95 s"
      ]
     },
     {
@@ -3796,7 +3796,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 67% Completed | 23.08 s"
+      "[######################                  ] | 56% Completed | 23.05 s"
      ]
     },
     {
@@ -3804,7 +3804,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 67% Completed | 23.18 s"
+      "[######################                  ] | 56% Completed | 23.15 s"
      ]
     },
     {
@@ -3812,7 +3812,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 67% Completed | 23.28 s"
+      "[######################                  ] | 56% Completed | 23.25 s"
      ]
     },
     {
@@ -3820,7 +3820,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 68% Completed | 23.38 s"
+      "[######################                  ] | 57% Completed | 23.35 s"
      ]
     },
     {
@@ -3828,7 +3828,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 68% Completed | 23.48 s"
+      "[######################                  ] | 57% Completed | 23.45 s"
      ]
     },
     {
@@ -3836,7 +3836,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 68% Completed | 23.58 s"
+      "[######################                  ] | 57% Completed | 23.56 s"
      ]
     },
     {
@@ -3844,7 +3844,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 68% Completed | 23.68 s"
+      "[######################                  ] | 57% Completed | 23.66 s"
      ]
     },
     {
@@ -3852,7 +3852,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 68% Completed | 23.79 s"
+      "[######################                  ] | 57% Completed | 23.76 s"
      ]
     },
     {
@@ -3860,7 +3860,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 69% Completed | 23.89 s"
+      "[######################                  ] | 57% Completed | 23.86 s"
      ]
     },
     {
@@ -3868,7 +3868,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###########################             ] | 69% Completed | 23.99 s"
+      "[#######################                 ] | 57% Completed | 23.96 s"
      ]
     },
     {
@@ -3876,7 +3876,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############################            ] | 70% Completed | 24.09 s"
+      "[#######################                 ] | 57% Completed | 24.07 s"
      ]
     },
     {
@@ -3884,7 +3884,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############################            ] | 70% Completed | 24.19 s"
+      "[#######################                 ] | 57% Completed | 24.17 s"
      ]
     },
     {
@@ -3892,7 +3892,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############################            ] | 71% Completed | 24.29 s"
+      "[#######################                 ] | 58% Completed | 24.27 s"
      ]
     },
     {
@@ -3900,7 +3900,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############################            ] | 71% Completed | 24.39 s"
+      "[#######################                 ] | 59% Completed | 24.37 s"
      ]
     },
     {
@@ -3908,7 +3908,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[############################            ] | 72% Completed | 24.50 s"
+      "[#######################                 ] | 59% Completed | 24.47 s"
      ]
     },
     {
@@ -3916,7 +3916,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############################           ] | 72% Completed | 24.60 s"
+      "[#######################                 ] | 59% Completed | 24.57 s"
      ]
     },
     {
@@ -3924,7 +3924,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############################           ] | 73% Completed | 24.70 s"
+      "[########################                ] | 60% Completed | 24.67 s"
      ]
     },
     {
@@ -3932,7 +3932,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############################           ] | 74% Completed | 24.80 s"
+      "[########################                ] | 60% Completed | 24.77 s"
      ]
     },
     {
@@ -3940,7 +3940,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#############################           ] | 74% Completed | 24.90 s"
+      "[########################                ] | 61% Completed | 24.88 s"
      ]
     },
     {
@@ -3948,7 +3948,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############################          ] | 75% Completed | 25.00 s"
+      "[########################                ] | 61% Completed | 24.98 s"
      ]
     },
     {
@@ -3956,7 +3956,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############################          ] | 75% Completed | 25.11 s"
+      "[########################                ] | 61% Completed | 25.08 s"
      ]
     },
     {
@@ -3964,7 +3964,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############################          ] | 76% Completed | 25.21 s"
+      "[#########################               ] | 62% Completed | 25.18 s"
      ]
     },
     {
@@ -3972,7 +3972,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############################          ] | 76% Completed | 25.31 s"
+      "[#########################               ] | 62% Completed | 25.28 s"
      ]
     },
     {
@@ -3980,7 +3980,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##############################          ] | 76% Completed | 25.41 s"
+      "[#########################               ] | 63% Completed | 25.38 s"
      ]
     },
     {
@@ -3988,7 +3988,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 77% Completed | 25.51 s"
+      "[#########################               ] | 63% Completed | 25.48 s"
      ]
     },
     {
@@ -3996,7 +3996,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 78% Completed | 25.61 s"
+      "[#########################               ] | 63% Completed | 25.58 s"
      ]
     },
     {
@@ -4004,7 +4004,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 78% Completed | 25.72 s"
+      "[#########################               ] | 63% Completed | 25.68 s"
      ]
     },
     {
@@ -4012,7 +4012,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 78% Completed | 25.82 s"
+      "[#########################               ] | 63% Completed | 25.78 s"
      ]
     },
     {
@@ -4020,7 +4020,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 78% Completed | 25.92 s"
+      "[#########################               ] | 64% Completed | 25.89 s"
      ]
     },
     {
@@ -4028,7 +4028,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 78% Completed | 26.02 s"
+      "[#########################               ] | 64% Completed | 25.99 s"
      ]
     },
     {
@@ -4036,7 +4036,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 78% Completed | 26.12 s"
+      "[#########################               ] | 64% Completed | 26.09 s"
      ]
     },
     {
@@ -4044,7 +4044,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 79% Completed | 26.22 s"
+      "[#########################               ] | 64% Completed | 26.19 s"
      ]
     },
     {
@@ -4052,7 +4052,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###############################         ] | 79% Completed | 26.33 s"
+      "[##########################              ] | 65% Completed | 26.29 s"
      ]
     },
     {
@@ -4060,7 +4060,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################################        ] | 80% Completed | 26.43 s"
+      "[##########################              ] | 65% Completed | 26.39 s"
      ]
     },
     {
@@ -4068,7 +4068,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################################        ] | 80% Completed | 26.53 s"
+      "[##########################              ] | 65% Completed | 26.49 s"
      ]
     },
     {
@@ -4076,7 +4076,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################################        ] | 81% Completed | 26.63 s"
+      "[##########################              ] | 65% Completed | 26.60 s"
      ]
     },
     {
@@ -4084,7 +4084,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[################################        ] | 82% Completed | 26.73 s"
+      "[##########################              ] | 66% Completed | 26.70 s"
      ]
     },
     {
@@ -4092,7 +4092,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################################       ] | 82% Completed | 26.83 s"
+      "[##########################              ] | 66% Completed | 26.80 s"
      ]
     },
     {
@@ -4100,7 +4100,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################################       ] | 82% Completed | 26.93 s"
+      "[##########################              ] | 66% Completed | 26.90 s"
      ]
     },
     {
@@ -4108,7 +4108,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################################       ] | 82% Completed | 27.04 s"
+      "[##########################              ] | 66% Completed | 27.00 s"
      ]
     },
     {
@@ -4116,7 +4116,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################################       ] | 83% Completed | 27.14 s"
+      "[##########################              ] | 67% Completed | 27.11 s"
      ]
     },
     {
@@ -4124,7 +4124,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################################       ] | 84% Completed | 27.24 s"
+      "[##########################              ] | 67% Completed | 27.21 s"
      ]
     },
     {
@@ -4132,7 +4132,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#################################       ] | 84% Completed | 27.34 s"
+      "[##########################              ] | 67% Completed | 27.31 s"
      ]
     },
     {
@@ -4140,7 +4140,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################################      ] | 85% Completed | 27.44 s"
+      "[##########################              ] | 67% Completed | 27.41 s"
      ]
     },
     {
@@ -4148,7 +4148,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################################      ] | 85% Completed | 27.54 s"
+      "[##########################              ] | 67% Completed | 27.51 s"
      ]
     },
     {
@@ -4156,7 +4156,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################################      ] | 85% Completed | 27.64 s"
+      "[###########################             ] | 67% Completed | 27.61 s"
      ]
     },
     {
@@ -4164,7 +4164,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################################      ] | 86% Completed | 27.74 s"
+      "[###########################             ] | 67% Completed | 27.72 s"
      ]
     },
     {
@@ -4172,7 +4172,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[##################################      ] | 87% Completed | 27.85 s"
+      "[###########################             ] | 67% Completed | 27.82 s"
      ]
     },
     {
@@ -4180,7 +4180,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 87% Completed | 27.95 s"
+      "[###########################             ] | 67% Completed | 27.92 s"
      ]
     },
     {
@@ -4188,7 +4188,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 88% Completed | 28.05 s"
+      "[###########################             ] | 67% Completed | 28.02 s"
      ]
     },
     {
@@ -4196,7 +4196,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 88% Completed | 28.15 s"
+      "[###########################             ] | 68% Completed | 28.12 s"
      ]
     },
     {
@@ -4204,7 +4204,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 89% Completed | 28.25 s"
+      "[###########################             ] | 68% Completed | 28.23 s"
      ]
     },
     {
@@ -4212,7 +4212,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 89% Completed | 28.35 s"
+      "[###########################             ] | 68% Completed | 28.33 s"
      ]
     },
     {
@@ -4220,7 +4220,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 89% Completed | 28.46 s"
+      "[###########################             ] | 68% Completed | 28.43 s"
      ]
     },
     {
@@ -4228,7 +4228,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[###################################     ] | 89% Completed | 28.56 s"
+      "[###########################             ] | 69% Completed | 28.53 s"
      ]
     },
     {
@@ -4236,7 +4236,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################    ] | 90% Completed | 28.66 s"
+      "[###########################             ] | 69% Completed | 28.63 s"
      ]
     },
     {
@@ -4244,7 +4244,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################    ] | 90% Completed | 28.76 s"
+      "[###########################             ] | 69% Completed | 28.73 s"
      ]
     },
     {
@@ -4252,7 +4252,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################    ] | 91% Completed | 28.86 s"
+      "[############################            ] | 70% Completed | 28.83 s"
      ]
     },
     {
@@ -4260,7 +4260,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################    ] | 91% Completed | 28.96 s"
+      "[############################            ] | 70% Completed | 28.94 s"
      ]
     },
     {
@@ -4268,7 +4268,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################################   ] | 92% Completed | 29.06 s"
+      "[############################            ] | 71% Completed | 29.04 s"
      ]
     },
     {
@@ -4276,7 +4276,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################################   ] | 93% Completed | 29.17 s"
+      "[############################            ] | 71% Completed | 29.14 s"
      ]
     },
     {
@@ -4284,7 +4284,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################################   ] | 93% Completed | 29.27 s"
+      "[############################            ] | 71% Completed | 29.24 s"
      ]
     },
     {
@@ -4292,7 +4292,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################################   ] | 93% Completed | 29.37 s"
+      "[############################            ] | 72% Completed | 29.34 s"
      ]
     },
     {
@@ -4300,7 +4300,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################################   ] | 93% Completed | 29.47 s"
+      "[############################            ] | 72% Completed | 29.45 s"
      ]
     },
     {
@@ -4308,7 +4308,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[#####################################   ] | 94% Completed | 29.57 s"
+      "[############################            ] | 72% Completed | 29.55 s"
      ]
     },
     {
@@ -4316,7 +4316,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################################  ] | 95% Completed | 29.67 s"
+      "[############################            ] | 72% Completed | 29.65 s"
      ]
     },
     {
@@ -4324,7 +4324,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################################  ] | 95% Completed | 29.77 s"
+      "[#############################           ] | 72% Completed | 29.75 s"
      ]
     },
     {
@@ -4332,7 +4332,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################################  ] | 96% Completed | 29.88 s"
+      "[#############################           ] | 73% Completed | 29.85 s"
      ]
     },
     {
@@ -4340,7 +4340,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################################  ] | 96% Completed | 29.98 s"
+      "[#############################           ] | 74% Completed | 29.95 s"
      ]
     },
     {
@@ -4348,7 +4348,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[######################################  ] | 97% Completed | 30.08 s"
+      "[#############################           ] | 74% Completed | 30.05 s"
      ]
     },
     {
@@ -4356,7 +4356,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################### ] | 97% Completed | 30.18 s"
+      "[#############################           ] | 74% Completed | 30.15 s"
      ]
     },
     {
@@ -4364,7 +4364,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################### ] | 97% Completed | 30.28 s"
+      "[#############################           ] | 74% Completed | 30.25 s"
      ]
     },
     {
@@ -4372,7 +4372,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################### ] | 98% Completed | 30.38 s"
+      "[##############################          ] | 75% Completed | 30.36 s"
      ]
     },
     {
@@ -4380,7 +4380,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[####################################### ] | 99% Completed | 30.49 s"
+      "[##############################          ] | 75% Completed | 30.46 s"
      ]
     },
     {
@@ -4388,7 +4388,575 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "[########################################] | 100% Completed | 30.59 s"
+      "[##############################          ] | 76% Completed | 30.56 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##############################          ] | 76% Completed | 30.66 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##############################          ] | 76% Completed | 30.76 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##############################          ] | 76% Completed | 30.86 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 77% Completed | 30.96 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 77% Completed | 31.06 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 78% Completed | 31.17 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 78% Completed | 31.27 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 78% Completed | 31.37 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 78% Completed | 31.47 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 78% Completed | 31.57 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 78% Completed | 31.67 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 79% Completed | 31.78 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###############################         ] | 79% Completed | 31.88 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 80% Completed | 31.98 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 80% Completed | 32.08 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 80% Completed | 32.18 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 80% Completed | 32.28 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 81% Completed | 32.38 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 82% Completed | 32.49 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[################################        ] | 82% Completed | 32.59 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 82% Completed | 32.69 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 82% Completed | 32.79 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 82% Completed | 32.89 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 83% Completed | 32.99 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 83% Completed | 33.09 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 84% Completed | 33.20 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 84% Completed | 33.30 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#################################       ] | 84% Completed | 33.40 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 85% Completed | 33.50 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 85% Completed | 33.60 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 85% Completed | 33.70 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 86% Completed | 33.80 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 86% Completed | 33.91 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 87% Completed | 34.01 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[##################################      ] | 87% Completed | 34.11 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 87% Completed | 34.21 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 88% Completed | 34.31 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 88% Completed | 34.42 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 88% Completed | 34.52 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 89% Completed | 34.62 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 89% Completed | 34.72 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 89% Completed | 34.82 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 89% Completed | 34.92 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[###################################     ] | 89% Completed | 35.03 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################    ] | 90% Completed | 35.13 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################    ] | 91% Completed | 35.23 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################    ] | 91% Completed | 35.33 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################    ] | 91% Completed | 35.43 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################    ] | 91% Completed | 35.54 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 92% Completed | 35.64 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 92% Completed | 35.74 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 93% Completed | 35.84 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 93% Completed | 35.94 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 93% Completed | 36.04 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 93% Completed | 36.14 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 93% Completed | 36.24 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 94% Completed | 36.34 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[#####################################   ] | 94% Completed | 36.44 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 95% Completed | 36.55 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 95% Completed | 36.65 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 95% Completed | 36.75 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 96% Completed | 36.85 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 96% Completed | 36.95 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 97% Completed | 37.06 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[######################################  ] | 97% Completed | 37.16 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################### ] | 97% Completed | 37.26 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################### ] | 97% Completed | 37.36 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################### ] | 98% Completed | 37.46 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################### ] | 99% Completed | 37.56 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[####################################### ] | 99% Completed | 37.66 s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[########################################] | 100% Completed | 37.76 s"
      ]
     },
     {
@@ -4453,10 +5021,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:20.640785Z",
-     "iopub.status.busy": "2025-11-06T01:28:20.640179Z",
-     "iopub.status.idle": "2025-11-06T01:28:23.738976Z",
-     "shell.execute_reply": "2025-11-06T01:28:23.738468Z"
+     "iopub.execute_input": "2025-11-13T01:28:29.675194Z",
+     "iopub.status.busy": "2025-11-13T01:28:29.674326Z",
+     "iopub.status.idle": "2025-11-13T01:28:32.933471Z",
+     "shell.execute_reply": "2025-11-13T01:28:32.932966Z"
     },
     "tags": []
    },
@@ -4835,11 +5403,11 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 3MB\n",
-       "Dimensions:  (site: 3, time: 27667)\n",
+       "Dimensions:  (site: 3, time: 27698)\n",
        "Coordinates:\n",
        "    lat      (site) float32 12B 46.7 41.0 55.3\n",
        "    lon      (site) float32 12B -75.4 -85.0 -65.5\n",
-       "  * time     (time) datetime64[ns] 221kB 1950-01-01 1950-01-02 ... 2025-09-30\n",
+       "  * time     (time) datetime64[ns] 222kB 1950-01-01 1950-01-02 ... 2025-10-31\n",
        "Dimensions without coordinates: site\n",
        "Data variables:\n",
        "    tas      (time, site) float32 332kB dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;\n",
@@ -4864,10 +5432,10 @@
        "    abstract:                ERA5-Land provides hourly high resolution inform...\n",
        "    dataset_description:     https://www.ecmwf.int/en/era5-land\n",
        "    attribution:             Contains modified Copernicus Climate Change Serv...\n",
-       "    citation:                Muñoz Sabater, J., (2021): ERA5-Land hourly data...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-3a01bce3-608e-44a6-9eb7-3acd527f021e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3a01bce3-608e-44a6-9eb7-3acd527f021e' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>site</span>: 3</li><li><span class='xr-has-index'>time</span>: 27667</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-9d6c0886-f675-46b8-b103-b5b8eb26bba4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9d6c0886-f675-46b8-b103-b5b8eb26bba4' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>46.7 41.0 55.3</div><input id='attrs-115fcd8c-9890-43fc-98f0-824db933d93f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-115fcd8c-9890-43fc-98f0-824db933d93f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9c1282bb-9e30-467c-ada7-0d4160e8c255' class='xr-var-data-in' type='checkbox'><label for='data-9c1282bb-9e30-467c-ada7-0d4160e8c255' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([46.7, 41. , 55.3], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-75.4 -85.0 -65.5</div><input id='attrs-f52941f2-b9f8-4dfa-8caa-03a708d30f3b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f52941f2-b9f8-4dfa-8caa-03a708d30f3b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c79e048b-4ab0-4d26-903d-f89496805566' class='xr-var-data-in' type='checkbox'><label for='data-c79e048b-4ab0-4d26-903d-f89496805566' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-75.4, -85. , -65.5], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1950-01-01 ... 2025-09-30</div><input id='attrs-21b31bb2-5c46-4cae-a2d3-5c5c6c3653b7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-21b31bb2-5c46-4cae-a2d3-5c5c6c3653b7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-37b549ff-dc35-48f3-8b47-31e07925d924' class='xr-var-data-in' type='checkbox'><label for='data-37b549ff-dc35-48f3-8b47-31e07925d924' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1950-01-01T00:00:00.000000000&#x27;, &#x27;1950-01-02T00:00:00.000000000&#x27;,\n",
-       "       &#x27;1950-01-03T00:00:00.000000000&#x27;, ..., &#x27;2025-09-28T00:00:00.000000000&#x27;,\n",
-       "       &#x27;2025-09-29T00:00:00.000000000&#x27;, &#x27;2025-09-30T00:00:00.000000000&#x27;],\n",
-       "      shape=(27667,), dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4c2e06b6-a72b-42fd-a55b-8da2c8567af9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4c2e06b6-a72b-42fd-a55b-8da2c8567af9' class='xr-section-summary' >Data variables: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-ad177d18-7652-45fe-87e2-3a9a1d0e859c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ad177d18-7652-45fe-87e2-3a9a1d0e859c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cc7cf4b8-a627-42cc-b1e5-2a81ac26362a' class='xr-var-data-in' type='checkbox'><label for='data-cc7cf4b8-a627-42cc-b1e5-2a81ac26362a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:44:23] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    citation:                Muñoz Sabater, J., (2021): ERA5-Land hourly data...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d0e7c3bc-fefa-484a-bd3b-8a5868975e5f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d0e7c3bc-fefa-484a-bd3b-8a5868975e5f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>site</span>: 3</li><li><span class='xr-has-index'>time</span>: 27698</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-50c76283-6736-470e-981f-b777c89626a4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-50c76283-6736-470e-981f-b777c89626a4' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>46.7 41.0 55.3</div><input id='attrs-ba950022-cbb1-408b-b3a2-4b14218998d1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ba950022-cbb1-408b-b3a2-4b14218998d1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c6e6f674-a791-4139-981e-fde208e044e6' class='xr-var-data-in' type='checkbox'><label for='data-c6e6f674-a791-4139-981e-fde208e044e6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([46.7, 41. , 55.3], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-75.4 -85.0 -65.5</div><input id='attrs-94d53a9c-8047-4028-aa24-6d635c713be8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-94d53a9c-8047-4028-aa24-6d635c713be8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb2baad5-b7de-4fac-8ba9-eba49f0365d5' class='xr-var-data-in' type='checkbox'><label for='data-eb2baad5-b7de-4fac-8ba9-eba49f0365d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-75.4, -85. , -65.5], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1950-01-01 ... 2025-10-31</div><input id='attrs-5c9d1b2f-f138-46e1-9c31-19fc03201579' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5c9d1b2f-f138-46e1-9c31-19fc03201579' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eaa49ba8-b86a-424a-a1ee-8d8123041d19' class='xr-var-data-in' type='checkbox'><label for='data-eaa49ba8-b86a-424a-a1ee-8d8123041d19' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1950-01-01T00:00:00.000000000&#x27;, &#x27;1950-01-02T00:00:00.000000000&#x27;,\n",
+       "       &#x27;1950-01-03T00:00:00.000000000&#x27;, ..., &#x27;2025-10-29T00:00:00.000000000&#x27;,\n",
+       "       &#x27;2025-10-30T00:00:00.000000000&#x27;, &#x27;2025-10-31T00:00:00.000000000&#x27;],\n",
+       "      shape=(27698,), dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5a54b3b7-dc58-4466-8b9b-533de2edfa7e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5a54b3b7-dc58-4466-8b9b-533de2edfa7e' class='xr-section-summary' >Data variables: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-883ab49c-9bd3-424a-8bbb-6917eccbd8fe' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-883ab49c-9bd3-424a-8bbb-6917eccbd8fe' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-745779ec-4dc2-46d2-a963-29c9808d08c1' class='xr-var-data-in' type='checkbox'><label for='data-745779ec-4dc2-46d2-a963-29c9808d08c1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:44:23] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -4882,13 +5450,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -4936,11 +5504,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmin</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-ac50a874-a849-4383-92ab-043aca732b4f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ac50a874-a849-4383-92ab-043aca732b4f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-af0c4d09-3e46-4cec-85d7-00e9a52a05c0' class='xr-var-data-in' type='checkbox'><label for='data-af0c4d09-3e46-4cec-85d7-00e9a52a05c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:14:43] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmin</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-92144a33-7340-46bc-8a82-8da4e972e361' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-92144a33-7340-46bc-8a82-8da4e972e361' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cbdaabc4-7422-4569-acf4-73b1adab0247' class='xr-var-data-in' type='checkbox'><label for='data-cbdaabc4-7422-4569-acf4-73b1adab0247' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:14:43] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -4955,13 +5523,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5009,11 +5577,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmax</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-7773bfb0-e2ae-4eac-9309-932337ec0159' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7773bfb0-e2ae-4eac-9309-932337ec0159' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3a94dce0-0467-47c3-9125-ede8e4011781' class='xr-var-data-in' type='checkbox'><label for='data-3a94dce0-0467-47c3-9125-ede8e4011781' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:23:27] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmax</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-1f65ab04-2552-4fd5-82ba-619b15adf316' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1f65ab04-2552-4fd5-82ba-619b15adf316' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ea56fb44-93b1-4cc4-a940-85d62b0e62ca' class='xr-var-data-in' type='checkbox'><label for='data-ea56fb44-93b1-4cc4-a940-85d62b0e62ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:23:27] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5028,13 +5596,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5082,11 +5650,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>pr</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-26c4413b-1a84-48da-be99-04b06b49f84f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-26c4413b-1a84-48da-be99-04b06b49f84f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f84ea909-a17f-4e24-b46f-e3167fc5f779' class='xr-var-data-in' type='checkbox'><label for='data-f84ea909-a17f-4e24-b46f-e3167fc5f779' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Precipitation</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Total precipitation thickness converted to mass flux using a water density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Total precipitation</dd><dt><span>original_variable :</span></dt><dd>tp</dd><dt><span>standard_name :</span></dt><dd>precipitation_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:30:54] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>pr</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-041d4ee6-e360-447b-8b38-14da878b623d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-041d4ee6-e360-447b-8b38-14da878b623d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-90af7249-e346-46e1-9596-9ac20d355ccd' class='xr-var-data-in' type='checkbox'><label for='data-90af7249-e346-46e1-9596-9ac20d355ccd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Precipitation</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Total precipitation thickness converted to mass flux using a water density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Total precipitation</dd><dt><span>original_variable :</span></dt><dd>tp</dd><dt><span>standard_name :</span></dt><dd>precipitation_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:30:54] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5101,13 +5669,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5155,11 +5723,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>prsn</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-cbb85f9f-1d6c-4a4c-a51e-aa10b5f5e75b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cbb85f9f-1d6c-4a4c-a51e-aa10b5f5e75b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b85ce32e-ad7f-438e-9ea7-a6a5e4e0a57b' class='xr-var-data-in' type='checkbox'><label for='data-b85ce32e-ad7f-438e-9ea7-a6a5e4e0a57b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Snowfall flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 hour)</dd><dt><span>comments :</span></dt><dd>Converted from Snowfall (water equivalent) using a density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Snowfall</dd><dt><span>original_variable :</span></dt><dd>sf</dd><dt><span>standard_name :</span></dt><dd>snowfall_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:36:49] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>prsn</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-2fb953c9-e309-4e98-b024-bbed6d7c146f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2fb953c9-e309-4e98-b024-bbed6d7c146f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-483b8e24-6320-4c5b-803c-2a0e9aa05c2d' class='xr-var-data-in' type='checkbox'><label for='data-483b8e24-6320-4c5b-803c-2a0e9aa05c2d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Snowfall flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 hour)</dd><dt><span>comments :</span></dt><dd>Converted from Snowfall (water equivalent) using a density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Snowfall</dd><dt><span>original_variable :</span></dt><dd>sf</dd><dt><span>standard_name :</span></dt><dd>snowfall_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:36:49] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5174,13 +5742,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5228,11 +5796,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rlds</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-eae2410d-ec0d-4355-a2ca-4e2415f3f166' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eae2410d-ec0d-4355-a2ca-4e2415f3f166' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-84137c8a-2c93-480d-9c9d-c90ab2d18738' class='xr-var-data-in' type='checkbox'><label for='data-84137c8a-2c93-480d-9c9d-c90ab2d18738' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of thermal (also known as longwave or terrestrial) radiation emitted by the atmosphere and clouds that reaches a horizontal plane at the surface of the Earth. </dd><dt><span>original_long_name :</span></dt><dd>Surface thermal radiation downwards</dd><dt><span>original_variable :</span></dt><dd>strd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:53:12] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rlds</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-f83fa041-6b2a-4b47-b2b1-0beaf12fb639' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f83fa041-6b2a-4b47-b2b1-0beaf12fb639' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1c6b995a-ad01-4b96-ba9e-94c2037b66c0' class='xr-var-data-in' type='checkbox'><label for='data-1c6b995a-ad01-4b96-ba9e-94c2037b66c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of thermal (also known as longwave or terrestrial) radiation emitted by the atmosphere and clouds that reaches a horizontal plane at the surface of the Earth. </dd><dt><span>original_long_name :</span></dt><dd>Surface thermal radiation downwards</dd><dt><span>original_variable :</span></dt><dd>strd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:53:12] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5247,13 +5815,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5301,11 +5869,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rls</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-f8d7e0f5-093e-418b-bf33-d87cf4904e8b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f8d7e0f5-093e-418b-bf33-d87cf4904e8b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4a8099a0-b6c6-431f-950f-8a95a7897284' class='xr-var-data-in' type='checkbox'><label for='data-4a8099a0-b6c6-431f-950f-8a95a7897284' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Thermal radiation (also known as longwave or terrestrial radiation) refers to radiation emitted by the atmosphere, clouds and the surface of the Earth. This parameter is the difference between downward and upward thermal radiation at the surface of the Earth. It the amount passing through a horizontal plane.</dd><dt><span>original_long_name :</span></dt><dd>Surface net thermal radiation</dd><dt><span>original_variable :</span></dt><dd>str</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:03:58] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rls</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-c63c9d75-0297-4504-9c88-5dca0e497bcd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c63c9d75-0297-4504-9c88-5dca0e497bcd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d7ddd824-020f-474c-b95b-05ef9fb97a66' class='xr-var-data-in' type='checkbox'><label for='data-d7ddd824-020f-474c-b95b-05ef9fb97a66' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Thermal radiation (also known as longwave or terrestrial radiation) refers to radiation emitted by the atmosphere, clouds and the surface of the Earth. This parameter is the difference between downward and upward thermal radiation at the surface of the Earth. It the amount passing through a horizontal plane.</dd><dt><span>original_long_name :</span></dt><dd>Surface net thermal radiation</dd><dt><span>original_variable :</span></dt><dd>str</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:03:58] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5320,13 +5888,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5374,11 +5942,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rsds</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-c7971d20-ba35-4631-8327-bf7511b2e41a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c7971d20-ba35-4631-8327-bf7511b2e41a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-985d6896-cf20-4b8b-94ca-af24ee5bacb6' class='xr-var-data-in' type='checkbox'><label for='data-985d6896-cf20-4b8b-94ca-af24ee5bacb6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth. This parameter comprises both direct and diffuse solar radiation</dd><dt><span>original_long_name :</span></dt><dd>Surface solar radiation downwards</dd><dt><span>original_variable :</span></dt><dd>ssrd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:13:31] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rsds</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-951c3728-167b-42f0-8577-761b3639861d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-951c3728-167b-42f0-8577-761b3639861d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f1e1d695-8825-4d8f-b7f4-38ad2f42e553' class='xr-var-data-in' type='checkbox'><label for='data-f1e1d695-8825-4d8f-b7f4-38ad2f42e553' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth. This parameter comprises both direct and diffuse solar radiation</dd><dt><span>original_long_name :</span></dt><dd>Surface solar radiation downwards</dd><dt><span>original_variable :</span></dt><dd>ssrd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:13:31] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5393,13 +5961,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5447,11 +6015,11 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rss</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-755eebe2-d0f3-4983-846d-ce43131911f5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-755eebe2-d0f3-4983-846d-ce43131911f5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f46ac827-618f-4d02-846c-abe08fe6f671' class='xr-var-data-in' type='checkbox'><label for='data-f46ac827-618f-4d02-846c-abe08fe6f671' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth (both direct and diffuse) minus the amount reflected by the Earth&#x27;s surface (which is governed by the albedo)</dd><dt><span>original_long_name :</span></dt><dd>Surface net solar radiation</dd><dt><span>original_variable :</span></dt><dd>ssr</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:22:47] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rss</span></div><div class='xr-var-dims'>(time, site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 3), meta=np.ndarray&gt;</div><input id='attrs-6ac36afb-faac-40f5-ab93-4b80445027ee' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6ac36afb-faac-40f5-ab93-4b80445027ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ab3aa7d-876c-46d6-820b-70a583296535' class='xr-var-data-in' type='checkbox'><label for='data-2ab3aa7d-876c-46d6-820b-70a583296535' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth (both direct and diffuse) minus the amount reflected by the Earth&#x27;s surface (which is governed by the albedo)</dd><dt><span>original_long_name :</span></dt><dd>Surface net solar radiation</dd><dt><span>original_variable :</span></dt><dd>ssr</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:22:47] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5466,13 +6034,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 324.22 kiB </td>\n",
+       "                        <td> 324.59 kiB </td>\n",
        "                        <td> 4.28 kiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 3) </td>\n",
+       "                        <td> (27698, 3) </td>\n",
        "                        <td> (365, 3) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -5520,26 +6088,26 @@
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"12.706308\" y=\"140.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >3</text>\n",
-       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27667</text>\n",
+       "  <text x=\"45.412617\" y=\"60.000000\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,45.412617,60.000000)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-da665d1c-83da-47b6-9ed8-8be298a5b515' class='xr-section-summary-in' type='checkbox'  ><label for='section-da665d1c-83da-47b6-9ed8-8be298a5b515' class='xr-section-summary' >Indexes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-41e3ad4f-fad7-443d-a3dc-1dc874e9ccde' class='xr-index-data-in' type='checkbox'/><label for='index-41e3ad4f-fad7-443d-a3dc-1dc874e9ccde' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1950-01-01&#x27;, &#x27;1950-01-02&#x27;, &#x27;1950-01-03&#x27;, &#x27;1950-01-04&#x27;,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-757a44a2-3ca6-4afd-a4db-43299fbebd80' class='xr-section-summary-in' type='checkbox'  ><label for='section-757a44a2-3ca6-4afd-a4db-43299fbebd80' class='xr-section-summary' >Indexes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-c85de5cc-3787-4f46-824d-a2986f60185a' class='xr-index-data-in' type='checkbox'/><label for='index-c85de5cc-3787-4f46-824d-a2986f60185a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1950-01-01&#x27;, &#x27;1950-01-02&#x27;, &#x27;1950-01-03&#x27;, &#x27;1950-01-04&#x27;,\n",
        "               &#x27;1950-01-05&#x27;, &#x27;1950-01-06&#x27;, &#x27;1950-01-07&#x27;, &#x27;1950-01-08&#x27;,\n",
        "               &#x27;1950-01-09&#x27;, &#x27;1950-01-10&#x27;,\n",
        "               ...\n",
-       "               &#x27;2025-09-21&#x27;, &#x27;2025-09-22&#x27;, &#x27;2025-09-23&#x27;, &#x27;2025-09-24&#x27;,\n",
-       "               &#x27;2025-09-25&#x27;, &#x27;2025-09-26&#x27;, &#x27;2025-09-27&#x27;, &#x27;2025-09-28&#x27;,\n",
-       "               &#x27;2025-09-29&#x27;, &#x27;2025-09-30&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=27667, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ba3e9281-7888-489d-b8f9-dd137177961b' class='xr-section-summary-in' type='checkbox'  ><label for='section-ba3e9281-7888-489d-b8f9-dd137177961b' class='xr-section-summary' >Attributes: <span>(27)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.9</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>doi :</span></dt><dd>https://doi.org/10.24381/cds.e2161bac</dd><dt><span>domain :</span></dt><dd>NAM</dd><dt><span>frequency :</span></dt><dd>day</dd><dt><span>history :</span></dt><dd>[2022-12-25 09:07:39.901698] Converted variables and modified metadata for CF-like compliance. 2022-06-14 22:47:32 GMT by grib_to_netcdf-2.24.3: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data0/adaptor.mars.internal-1655246820.5771172-15214-2-143cd489-ece2-4311-85e6-aa6a10567823.nc /cache/tmp/143cd489-ece2-4311-85e6-aa6a10567823-adaptor.mars.internal-1655246683.1830711-15214-3-tmp.grib</dd><dt><span>institution :</span></dt><dd>ECMWF</dd><dt><span>intake_esm_dataset_key :</span></dt><dd>ECMWF_ERA5-Land_NAM.NAM.raw.D</dd><dt><span>intake_esm_vars :</span></dt><dd>tas</dd><dt><span>license :</span></dt><dd>Please acknowledge the use of ERA5-Land as stated in the Copernicus C3S/CAMS License agreement http://apps.ecmwf.int/datasets/licences/copernicus/</dd><dt><span>license_type :</span></dt><dd>permissive</dd><dt><span>processing_level :</span></dt><dd>raw</dd><dt><span>project :</span></dt><dd>era5-land</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>source :</span></dt><dd>ERA5-Land</dd><dt><span>table_date :</span></dt><dd>2022-12-21</dd><dt><span>table_id :</span></dt><dd>ECMWF</dd><dt><span>type :</span></dt><dd>reanalysis</dd><dt><span>format :</span></dt><dd>netcdf</dd><dt><span>title :</span></dt><dd>ERA5-Land : daily</dd><dt><span>institute :</span></dt><dd>European Centre for Medium-Range Weather Forecasts</dd><dt><span>institute_id :</span></dt><dd>ECMWF</dd><dt><span>dataset_id :</span></dt><dd>ERA5-Land</dd><dt><span>abstract :</span></dt><dd>ERA5-Land provides hourly high resolution information of surface variables. The data is a replay of the land component of the ERA5 climate reanalysis with a finer spatial resolution: ~9km grid spacing. ERA5-Land includes information about uncertainties for all variables at reduced spatial and temporal resolutions. The model used in the production of ERA5-Land is the tiled ECMWF Scheme for Surface Exchanges over Land incorporating land surface hydrology (H-TESSEL).</dd><dt><span>dataset_description :</span></dt><dd>https://www.ecmwf.int/en/era5-land</dd><dt><span>attribution :</span></dt><dd>Contains modified Copernicus Climate Change Service Information 2022. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus Information or Data it contains.</dd><dt><span>citation :</span></dt><dd>Muñoz Sabater, J., (2021): ERA5-Land hourly data from 1950 to 1980. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (Accessed on 2022.06.07)</dd></dl></div></li></ul></div></div>"
+       "               &#x27;2025-10-22&#x27;, &#x27;2025-10-23&#x27;, &#x27;2025-10-24&#x27;, &#x27;2025-10-25&#x27;,\n",
+       "               &#x27;2025-10-26&#x27;, &#x27;2025-10-27&#x27;, &#x27;2025-10-28&#x27;, &#x27;2025-10-29&#x27;,\n",
+       "               &#x27;2025-10-30&#x27;, &#x27;2025-10-31&#x27;],\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=27698, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d361958e-8e31-4292-9c08-0c24a2a20d49' class='xr-section-summary-in' type='checkbox'  ><label for='section-d361958e-8e31-4292-9c08-0c24a2a20d49' class='xr-section-summary' >Attributes: <span>(27)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.9</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>doi :</span></dt><dd>https://doi.org/10.24381/cds.e2161bac</dd><dt><span>domain :</span></dt><dd>NAM</dd><dt><span>frequency :</span></dt><dd>day</dd><dt><span>history :</span></dt><dd>[2022-12-25 09:07:39.901698] Converted variables and modified metadata for CF-like compliance. 2022-06-14 22:47:32 GMT by grib_to_netcdf-2.24.3: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data0/adaptor.mars.internal-1655246820.5771172-15214-2-143cd489-ece2-4311-85e6-aa6a10567823.nc /cache/tmp/143cd489-ece2-4311-85e6-aa6a10567823-adaptor.mars.internal-1655246683.1830711-15214-3-tmp.grib</dd><dt><span>institution :</span></dt><dd>ECMWF</dd><dt><span>intake_esm_dataset_key :</span></dt><dd>ECMWF_ERA5-Land_NAM.NAM.raw.D</dd><dt><span>intake_esm_vars :</span></dt><dd>tas</dd><dt><span>license :</span></dt><dd>Please acknowledge the use of ERA5-Land as stated in the Copernicus C3S/CAMS License agreement http://apps.ecmwf.int/datasets/licences/copernicus/</dd><dt><span>license_type :</span></dt><dd>permissive</dd><dt><span>processing_level :</span></dt><dd>raw</dd><dt><span>project :</span></dt><dd>era5-land</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>source :</span></dt><dd>ERA5-Land</dd><dt><span>table_date :</span></dt><dd>2022-12-21</dd><dt><span>table_id :</span></dt><dd>ECMWF</dd><dt><span>type :</span></dt><dd>reanalysis</dd><dt><span>format :</span></dt><dd>netcdf</dd><dt><span>title :</span></dt><dd>ERA5-Land : daily</dd><dt><span>institute :</span></dt><dd>European Centre for Medium-Range Weather Forecasts</dd><dt><span>institute_id :</span></dt><dd>ECMWF</dd><dt><span>dataset_id :</span></dt><dd>ERA5-Land</dd><dt><span>abstract :</span></dt><dd>ERA5-Land provides hourly high resolution information of surface variables. The data is a replay of the land component of the ERA5 climate reanalysis with a finer spatial resolution: ~9km grid spacing. ERA5-Land includes information about uncertainties for all variables at reduced spatial and temporal resolutions. The model used in the production of ERA5-Land is the tiled ECMWF Scheme for Surface Exchanges over Land incorporating land surface hydrology (H-TESSEL).</dd><dt><span>dataset_description :</span></dt><dd>https://www.ecmwf.int/en/era5-land</dd><dt><span>attribution :</span></dt><dd>Contains modified Copernicus Climate Change Service Information 2022. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus Information or Data it contains.</dd><dt><span>citation :</span></dt><dd>Muñoz Sabater, J., (2021): ERA5-Land hourly data from 1950 to 1980. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (Accessed on 2022.06.07)</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 3MB\n",
-       "Dimensions:  (site: 3, time: 27667)\n",
+       "Dimensions:  (site: 3, time: 27698)\n",
        "Coordinates:\n",
        "    lat      (site) float32 12B 46.7 41.0 55.3\n",
        "    lon      (site) float32 12B -75.4 -85.0 -65.5\n",
-       "  * time     (time) datetime64[ns] 221kB 1950-01-01 1950-01-02 ... 2025-09-30\n",
+       "  * time     (time) datetime64[ns] 222kB 1950-01-01 1950-01-02 ... 2025-10-31\n",
        "Dimensions without coordinates: site\n",
        "Data variables:\n",
        "    tas      (time, site) float32 332kB dask.array<chunksize=(365, 3), meta=np.ndarray>\n",
@@ -5606,10 +6174,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:23.742856Z",
-     "iopub.status.busy": "2025-11-06T01:28:23.742116Z",
-     "iopub.status.idle": "2025-11-06T01:28:23.823338Z",
-     "shell.execute_reply": "2025-11-06T01:28:23.822803Z"
+     "iopub.execute_input": "2025-11-13T01:28:32.937226Z",
+     "iopub.status.busy": "2025-11-13T01:28:32.936490Z",
+     "iopub.status.idle": "2025-11-13T01:28:33.017686Z",
+     "shell.execute_reply": "2025-11-13T01:28:33.017194Z"
     },
     "tags": []
    },
@@ -5995,7 +6563,7 @@
        "    distance  (site) float64 24B 3.335e+03 0.0 0.08494\n",
        "Dimensions without coordinates: site\n",
        "Attributes:\n",
-       "    units:    m</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'distance'</div><ul class='xr-dim-list'><li><span>site</span>: 3</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-007fe722-1831-4f90-8cb1-917b61134ea2' class='xr-array-in' type='checkbox' checked><label for='section-007fe722-1831-4f90-8cb1-917b61134ea2' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>3.335e+03 0.0 0.08494</span></div><div class='xr-array-data'><pre>array([3.33502567e+03, 0.00000000e+00, 8.49373197e-02])</pre></div></div></li><li class='xr-section-item'><input id='section-d437478c-74c6-42cf-b5ca-a883d32bca6e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d437478c-74c6-42cf-b5ca-a883d32bca6e' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>46.7 41.0 55.3</div><input id='attrs-a9ff5abe-3995-4c4f-9f23-bbad96b66953' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a9ff5abe-3995-4c4f-9f23-bbad96b66953' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-53577a33-f7ae-464a-9024-0a48aa5773ce' class='xr-var-data-in' type='checkbox'><label for='data-53577a33-f7ae-464a-9024-0a48aa5773ce' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([46.7, 41. , 55.3], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-75.4 -85.0 -65.5</div><input id='attrs-1773a77c-abcc-4a5f-a0d1-9ec3a9a37c58' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1773a77c-abcc-4a5f-a0d1-9ec3a9a37c58' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6475626b-3d3d-4be3-bf1a-058bac99cf42' class='xr-var-data-in' type='checkbox'><label for='data-6475626b-3d3d-4be3-bf1a-058bac99cf42' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-75.4, -85. , -65.5], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>distance</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>3.335e+03 0.0 0.08494</div><input id='attrs-d5b1ca43-c513-4064-bff9-9d4161ec9002' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d5b1ca43-c513-4064-bff9-9d4161ec9002' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e8e9cf7b-b8a7-41c3-bdfb-680d70bbf92a' class='xr-var-data-in' type='checkbox'><label for='data-e8e9cf7b-b8a7-41c3-bdfb-680d70bbf92a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd></dl></div><div class='xr-var-data'><pre>array([3.33502567e+03, 0.00000000e+00, 8.49373197e-02])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1ee3b75e-1a10-4276-9b96-16e58ed36ff8' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1ee3b75e-1a10-4276-9b96-16e58ed36ff8' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-9d1ff60f-6936-499f-8a87-54e443926523' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9d1ff60f-6936-499f-8a87-54e443926523' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd></dl></div></li></ul></div></div>"
+       "    units:    m</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'distance'</div><ul class='xr-dim-list'><li><span>site</span>: 3</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-78fc375d-8488-49da-a7fc-abc182d87d6a' class='xr-array-in' type='checkbox' checked><label for='section-78fc375d-8488-49da-a7fc-abc182d87d6a' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>3.335e+03 0.0 0.08494</span></div><div class='xr-array-data'><pre>array([3.33502567e+03, 0.00000000e+00, 8.49373197e-02])</pre></div></div></li><li class='xr-section-item'><input id='section-a6636692-58cf-477b-a807-513e6f17376e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a6636692-58cf-477b-a807-513e6f17376e' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>46.7 41.0 55.3</div><input id='attrs-779ceb26-2b89-4c19-8063-088ac74eb126' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-779ceb26-2b89-4c19-8063-088ac74eb126' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c6d937c9-e3e9-4a02-bf99-a678233e93b1' class='xr-var-data-in' type='checkbox'><label for='data-c6d937c9-e3e9-4a02-bf99-a678233e93b1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([46.7, 41. , 55.3], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-75.4 -85.0 -65.5</div><input id='attrs-b06b879c-7d81-4667-a2a4-e3019db3a864' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b06b879c-7d81-4667-a2a4-e3019db3a864' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2c4555d7-a777-4b4f-af6f-91dfd6c52cc8' class='xr-var-data-in' type='checkbox'><label for='data-2c4555d7-a777-4b4f-af6f-91dfd6c52cc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-75.4, -85. , -65.5], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>distance</span></div><div class='xr-var-dims'>(site)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>3.335e+03 0.0 0.08494</div><input id='attrs-4afcd946-7892-47fd-8476-420c71f33625' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4afcd946-7892-47fd-8476-420c71f33625' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e3a51db6-7caa-495f-bd2b-0bd84347bb96' class='xr-var-data-in' type='checkbox'><label for='data-e3a51db6-7caa-495f-bd2b-0bd84347bb96' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd></dl></div><div class='xr-var-data'><pre>array([3.33502567e+03, 0.00000000e+00, 8.49373197e-02])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c00d60be-be66-4de8-89c0-a6cfa528fbb1' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c00d60be-be66-4de8-89c0-a6cfa528fbb1' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-5d9b6ce6-b58f-42f0-a7d6-dd895c45a424' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5d9b6ce6-b58f-42f0-a7d6-dd895c45a424' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'distance' (site: 3)> Size: 24B\n",
@@ -6041,10 +6609,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:23.826223Z",
-     "iopub.status.busy": "2025-11-06T01:28:23.825803Z",
-     "iopub.status.idle": "2025-11-06T01:28:27.843926Z",
-     "shell.execute_reply": "2025-11-06T01:28:27.843237Z"
+     "iopub.execute_input": "2025-11-13T01:28:33.020607Z",
+     "iopub.status.busy": "2025-11-13T01:28:33.020255Z",
+     "iopub.status.idle": "2025-11-13T01:28:37.525580Z",
+     "shell.execute_reply": "2025-11-13T01:28:37.525027Z"
     },
     "tags": []
    },
@@ -6423,11 +6991,11 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 23GB\n",
-       "Dimensions:  (lat: 111, lon: 204, time: 27667)\n",
+       "Dimensions:  (lat: 111, lon: 204, time: 27698)\n",
        "Coordinates:\n",
        "  * lat      (lat) float32 444B 44.0 44.1 44.2 44.3 44.4 ... 54.7 54.8 54.9 55.0\n",
        "  * lon      (lon) float32 816B -80.5 -80.4 -80.3 -80.2 ... -60.4 -60.3 -60.2\n",
-       "  * time     (time) datetime64[ns] 221kB 1950-01-01 1950-01-02 ... 2025-09-30\n",
+       "  * time     (time) datetime64[ns] 222kB 1950-01-01 1950-01-02 ... 2025-10-31\n",
        "Data variables:\n",
        "    tas      (time, lat, lon) float32 3GB dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;\n",
        "    tasmin   (time, lat, lon) float32 3GB dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;\n",
@@ -6451,7 +7019,7 @@
        "    abstract:                ERA5-Land provides hourly high resolution inform...\n",
        "    dataset_description:     https://www.ecmwf.int/en/era5-land\n",
        "    attribution:             Contains modified Copernicus Climate Change Serv...\n",
-       "    citation:                Muñoz Sabater, J., (2021): ERA5-Land hourly data...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1a044669-8175-49ed-af26-ce9031b4c53d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1a044669-8175-49ed-af26-ce9031b4c53d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 111</li><li><span class='xr-has-index'>lon</span>: 204</li><li><span class='xr-has-index'>time</span>: 27667</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b4ad9480-d0a1-4d55-a8ac-9d2c74b98d8b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b4ad9480-d0a1-4d55-a8ac-9d2c74b98d8b' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>44.0 44.1 44.2 ... 54.8 54.9 55.0</div><input id='attrs-4a2c183a-4cc0-4e6f-a31b-1184151e4547' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4a2c183a-4cc0-4e6f-a31b-1184151e4547' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fce1022c-5efe-4e67-a59d-21d38553eade' class='xr-var-data-in' type='checkbox'><label for='data-fce1022c-5efe-4e67-a59d-21d38553eade' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([44. , 44.1, 44.2, 44.3, 44.4, 44.5, 44.6, 44.7, 44.8, 44.9, 45. , 45.1,\n",
+       "    citation:                Muñoz Sabater, J., (2021): ERA5-Land hourly data...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-454c105a-78e5-441f-84dc-52f006544238' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-454c105a-78e5-441f-84dc-52f006544238' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 111</li><li><span class='xr-has-index'>lon</span>: 204</li><li><span class='xr-has-index'>time</span>: 27698</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-65bd2d7f-b7d0-463a-b571-761e0728c07e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-65bd2d7f-b7d0-463a-b571-761e0728c07e' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>44.0 44.1 44.2 ... 54.8 54.9 55.0</div><input id='attrs-c423e5db-e6be-4d21-837b-d2a3d981dfc5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c423e5db-e6be-4d21-837b-d2a3d981dfc5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0159d931-e982-44f8-b353-64194e16a1c3' class='xr-var-data-in' type='checkbox'><label for='data-0159d931-e982-44f8-b353-64194e16a1c3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([44. , 44.1, 44.2, 44.3, 44.4, 44.5, 44.6, 44.7, 44.8, 44.9, 45. , 45.1,\n",
        "       45.2, 45.3, 45.4, 45.5, 45.6, 45.7, 45.8, 45.9, 46. , 46.1, 46.2, 46.3,\n",
        "       46.4, 46.5, 46.6, 46.7, 46.8, 46.9, 47. , 47.1, 47.2, 47.3, 47.4, 47.5,\n",
        "       47.6, 47.7, 47.8, 47.9, 48. , 48.1, 48.2, 48.3, 48.4, 48.5, 48.6, 48.7,\n",
@@ -6460,11 +7028,11 @@
        "       51.2, 51.3, 51.4, 51.5, 51.6, 51.7, 51.8, 51.9, 52. , 52.1, 52.2, 52.3,\n",
        "       52.4, 52.5, 52.6, 52.7, 52.8, 52.9, 53. , 53.1, 53.2, 53.3, 53.4, 53.5,\n",
        "       53.6, 53.7, 53.8, 53.9, 54. , 54.1, 54.2, 54.3, 54.4, 54.5, 54.6, 54.7,\n",
-       "       54.8, 54.9, 55. ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-80.5 -80.4 -80.3 ... -60.3 -60.2</div><input id='attrs-2f51290b-8091-4810-b64a-7ce64579683a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2f51290b-8091-4810-b64a-7ce64579683a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-018c0246-15d0-4a85-bd5c-9e3de32724ec' class='xr-var-data-in' type='checkbox'><label for='data-018c0246-15d0-4a85-bd5c-9e3de32724ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-80.5, -80.4, -80.3, ..., -60.4, -60.3, -60.2],\n",
-       "      shape=(204,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1950-01-01 ... 2025-09-30</div><input id='attrs-bb6933e0-2bbb-4ae7-a95d-68f8301db9d2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bb6933e0-2bbb-4ae7-a95d-68f8301db9d2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-27c3e055-82fe-4537-b736-1fdc14bdfc82' class='xr-var-data-in' type='checkbox'><label for='data-27c3e055-82fe-4537-b736-1fdc14bdfc82' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1950-01-01T00:00:00.000000000&#x27;, &#x27;1950-01-02T00:00:00.000000000&#x27;,\n",
-       "       &#x27;1950-01-03T00:00:00.000000000&#x27;, ..., &#x27;2025-09-28T00:00:00.000000000&#x27;,\n",
-       "       &#x27;2025-09-29T00:00:00.000000000&#x27;, &#x27;2025-09-30T00:00:00.000000000&#x27;],\n",
-       "      shape=(27667,), dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-077a8404-5eda-404b-a5c3-be131395cf08' class='xr-section-summary-in' type='checkbox'  checked><label for='section-077a8404-5eda-404b-a5c3-be131395cf08' class='xr-section-summary' >Data variables: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-1c0dbab1-8fdc-4974-819a-6b6ba07619e4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1c0dbab1-8fdc-4974-819a-6b6ba07619e4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7faa495e-2b24-408a-a5d5-06d50db1b067' class='xr-var-data-in' type='checkbox'><label for='data-7faa495e-2b24-408a-a5d5-06d50db1b067' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:44:23] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       54.8, 54.9, 55. ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-80.5 -80.4 -80.3 ... -60.3 -60.2</div><input id='attrs-8e96a2de-2da6-4b81-8764-d36397ff3589' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8e96a2de-2da6-4b81-8764-d36397ff3589' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-de846734-e4f8-4441-9bac-d21b499ccd5d' class='xr-var-data-in' type='checkbox'><label for='data-de846734-e4f8-4441-9bac-d21b499ccd5d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-80.5, -80.4, -80.3, ..., -60.4, -60.3, -60.2],\n",
+       "      shape=(204,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1950-01-01 ... 2025-10-31</div><input id='attrs-adb883f6-dabe-48c2-9116-1665186f5eda' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-adb883f6-dabe-48c2-9116-1665186f5eda' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3164920b-740d-4830-bdc9-3743821a8f12' class='xr-var-data-in' type='checkbox'><label for='data-3164920b-740d-4830-bdc9-3743821a8f12' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1950-01-01T00:00:00.000000000&#x27;, &#x27;1950-01-02T00:00:00.000000000&#x27;,\n",
+       "       &#x27;1950-01-03T00:00:00.000000000&#x27;, ..., &#x27;2025-10-29T00:00:00.000000000&#x27;,\n",
+       "       &#x27;2025-10-30T00:00:00.000000000&#x27;, &#x27;2025-10-31T00:00:00.000000000&#x27;],\n",
+       "      shape=(27698,), dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b2473a8b-0f27-4fbe-abc2-169068a10902' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b2473a8b-0f27-4fbe-abc2-169068a10902' class='xr-section-summary' >Data variables: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-868af85a-bcf8-494d-8fb2-7c6a33876b10' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-868af85a-bcf8-494d-8fb2-7c6a33876b10' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1ff7b8ff-40f8-4e3b-886c-0d70a6260c01' class='xr-var-data-in' type='checkbox'><label for='data-1ff7b8ff-40f8-4e3b-886c-0d70a6260c01' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:44:23] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6479,13 +7047,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -6524,9 +7092,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -6549,9 +7117,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -6580,11 +7148,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmin</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-4ff88424-3e4b-477b-8eeb-e551364069da' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4ff88424-3e4b-477b-8eeb-e551364069da' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-58998d1f-971a-4d57-ae59-3ca9d3700311' class='xr-var-data-in' type='checkbox'><label for='data-58998d1f-971a-4d57-ae59-3ca9d3700311' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:14:43] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmin</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-6015b14d-2723-4355-b027-9f468e99d8ca' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6015b14d-2723-4355-b027-9f468e99d8ca' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ad7e3ffb-b6d9-443e-a265-91c869a20610' class='xr-var-data-in' type='checkbox'><label for='data-ad7e3ffb-b6d9-443e-a265-91c869a20610' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:14:43] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6599,13 +7167,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -6644,9 +7212,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -6669,9 +7237,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -6700,11 +7268,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmax</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-2f0dc147-735d-4564-8b6f-097a066cd7c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2f0dc147-735d-4564-8b6f-097a066cd7c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87161808-45b8-4363-b66a-35efcbbb5d99' class='xr-var-data-in' type='checkbox'><label for='data-87161808-45b8-4363-b66a-35efcbbb5d99' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:23:27] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tasmax</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-5c9204d0-0c27-47df-9dfe-ce04958e8bfe' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5c9204d0-0c27-47df-9dfe-ce04958e8bfe' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6a6f937-6927-4537-a626-264ce547277e' class='xr-var-data-in' type='checkbox'><label for='data-e6a6f937-6927-4537-a626-264ce547277e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>2 metre temperature</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd><dt><span>original_variable :</span></dt><dd>t2m</dd><dt><span>standard_name :</span></dt><dd>air_temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:23:27] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6719,13 +7287,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -6764,9 +7332,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -6789,9 +7357,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -6820,11 +7388,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>pr</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-01ec4652-4cb0-4e10-9597-ae3c28f7a295' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-01ec4652-4cb0-4e10-9597-ae3c28f7a295' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c946f2c4-dcb0-4b14-a6c8-67f251fc42eb' class='xr-var-data-in' type='checkbox'><label for='data-c946f2c4-dcb0-4b14-a6c8-67f251fc42eb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Precipitation</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Total precipitation thickness converted to mass flux using a water density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Total precipitation</dd><dt><span>original_variable :</span></dt><dd>tp</dd><dt><span>standard_name :</span></dt><dd>precipitation_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:30:54] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>pr</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-20f88617-b7e9-4611-bbc8-657133bcb7d4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-20f88617-b7e9-4611-bbc8-657133bcb7d4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d32df9f1-ac65-40dc-bf34-f553ca9a4157' class='xr-var-data-in' type='checkbox'><label for='data-d32df9f1-ac65-40dc-bf34-f553ca9a4157' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Precipitation</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Total precipitation thickness converted to mass flux using a water density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Total precipitation</dd><dt><span>original_variable :</span></dt><dd>tp</dd><dt><span>standard_name :</span></dt><dd>precipitation_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:30:54] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6839,13 +7407,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -6884,9 +7452,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -6909,9 +7477,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -6940,11 +7508,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>prsn</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-7ac0f754-461e-4663-8a93-f08942db9bb9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7ac0f754-461e-4663-8a93-f08942db9bb9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3b8a8ded-ac37-45d7-bd4a-f4312131113f' class='xr-var-data-in' type='checkbox'><label for='data-3b8a8ded-ac37-45d7-bd4a-f4312131113f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Snowfall flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 hour)</dd><dt><span>comments :</span></dt><dd>Converted from Snowfall (water equivalent) using a density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Snowfall</dd><dt><span>original_variable :</span></dt><dd>sf</dd><dt><span>standard_name :</span></dt><dd>snowfall_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:36:49] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>prsn</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-48b91c9c-9695-4082-82a5-1015a25862c1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-48b91c9c-9695-4082-82a5-1015a25862c1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-368ea74e-622d-4b49-b0a5-cb622c835b13' class='xr-var-data-in' type='checkbox'><label for='data-368ea74e-622d-4b49-b0a5-cb622c835b13' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Snowfall flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 hour)</dd><dt><span>comments :</span></dt><dd>Converted from Snowfall (water equivalent) using a density of 1000 kg/m³.</dd><dt><span>original_long_name :</span></dt><dd>Snowfall</dd><dt><span>original_variable :</span></dt><dd>sf</dd><dt><span>standard_name :</span></dt><dd>snowfall_flux</dd><dt><span>units :</span></dt><dd>kg m-2 s-1</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:36:49] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6959,13 +7527,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -7004,9 +7572,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -7029,9 +7597,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -7060,11 +7628,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rlds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-b368a6e4-0a25-489a-ae4f-ac05c186a18d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b368a6e4-0a25-489a-ae4f-ac05c186a18d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-560b0567-073c-4c52-af8a-a1ca5c8f3174' class='xr-var-data-in' type='checkbox'><label for='data-560b0567-073c-4c52-af8a-a1ca5c8f3174' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of thermal (also known as longwave or terrestrial) radiation emitted by the atmosphere and clouds that reaches a horizontal plane at the surface of the Earth. </dd><dt><span>original_long_name :</span></dt><dd>Surface thermal radiation downwards</dd><dt><span>original_variable :</span></dt><dd>strd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:53:12] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rlds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-36a56169-6a5e-4ca7-a4e7-5ace660afa0c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-36a56169-6a5e-4ca7-a4e7-5ace660afa0c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-473928a1-0e9f-4619-a489-5bb27ac11c26' class='xr-var-data-in' type='checkbox'><label for='data-473928a1-0e9f-4619-a489-5bb27ac11c26' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of thermal (also known as longwave or terrestrial) radiation emitted by the atmosphere and clouds that reaches a horizontal plane at the surface of the Earth. </dd><dt><span>original_long_name :</span></dt><dd>Surface thermal radiation downwards</dd><dt><span>original_variable :</span></dt><dd>strd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 09:53:12] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -7079,13 +7647,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -7124,9 +7692,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -7149,9 +7717,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -7180,11 +7748,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rls</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-e7259fdf-fa8c-4e47-9304-24fd6400c9be' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e7259fdf-fa8c-4e47-9304-24fd6400c9be' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7c9733aa-5c92-4a6a-b1a1-cf299d9d0aa1' class='xr-var-data-in' type='checkbox'><label for='data-7c9733aa-5c92-4a6a-b1a1-cf299d9d0aa1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Thermal radiation (also known as longwave or terrestrial radiation) refers to radiation emitted by the atmosphere, clouds and the surface of the Earth. This parameter is the difference between downward and upward thermal radiation at the surface of the Earth. It the amount passing through a horizontal plane.</dd><dt><span>original_long_name :</span></dt><dd>Surface net thermal radiation</dd><dt><span>original_variable :</span></dt><dd>str</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:03:58] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rls</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-ecba2bd9-a89b-42d4-973a-156c174717a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ecba2bd9-a89b-42d4-973a-156c174717a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8bead9a8-3d7a-4926-9028-58c04328136a' class='xr-var-data-in' type='checkbox'><label for='data-8bead9a8-3d7a-4926-9028-58c04328136a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward longwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>Thermal radiation (also known as longwave or terrestrial radiation) refers to radiation emitted by the atmosphere, clouds and the surface of the Earth. This parameter is the difference between downward and upward thermal radiation at the surface of the Earth. It the amount passing through a horizontal plane.</dd><dt><span>original_long_name :</span></dt><dd>Surface net thermal radiation</dd><dt><span>original_variable :</span></dt><dd>str</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_longwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:03:58] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -7199,13 +7767,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -7244,9 +7812,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -7269,9 +7837,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -7300,11 +7868,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rsds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-c981a7b2-0d06-4c2c-858b-fe5b08f96a6f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c981a7b2-0d06-4c2c-858b-fe5b08f96a6f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d3d1a095-8e17-447b-94bb-dd032a773179' class='xr-var-data-in' type='checkbox'><label for='data-d3d1a095-8e17-447b-94bb-dd032a773179' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth. This parameter comprises both direct and diffuse solar radiation</dd><dt><span>original_long_name :</span></dt><dd>Surface solar radiation downwards</dd><dt><span>original_variable :</span></dt><dd>ssrd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:13:31] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rsds</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-37f99dda-e2a9-4010-98db-552325858b7f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-37f99dda-e2a9-4010-98db-552325858b7f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1b66a3d8-6086-4ed8-afab-961bd6e5450c' class='xr-var-data-in' type='checkbox'><label for='data-1b66a3d8-6086-4ed8-afab-961bd6e5450c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface downwelling shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth. This parameter comprises both direct and diffuse solar radiation</dd><dt><span>original_long_name :</span></dt><dd>Surface solar radiation downwards</dd><dt><span>original_variable :</span></dt><dd>ssrd</dd><dt><span>standard_name :</span></dt><dd>surface_downwelling_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:13:31] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -7319,13 +7887,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -7364,9 +7932,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -7389,9 +7957,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -7420,11 +7988,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rss</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-b4631b05-67a0-4c70-9db4-4bf0b0010e23' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b4631b05-67a0-4c70-9db4-4bf0b0010e23' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d04c05e0-ff00-4865-acba-72f4da356981' class='xr-var-data-in' type='checkbox'><label for='data-d04c05e0-ff00-4865-acba-72f4da356981' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth (both direct and diffuse) minus the amount reflected by the Earth&#x27;s surface (which is governed by the albedo)</dd><dt><span>original_long_name :</span></dt><dd>Surface net solar radiation</dd><dt><span>original_variable :</span></dt><dd>ssr</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:22:47] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rss</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(365, 60, 6), meta=np.ndarray&gt;</div><input id='attrs-51517434-81c4-43e5-b0a5-560528c8cd8b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-51517434-81c4-43e5-b0a5-560528c8cd8b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-69e2c12a-4ec7-4b5a-a040-0c8c733d77b1' class='xr-var-data-in' type='checkbox'><label for='data-69e2c12a-4ec7-4b5a-a040-0c8c733d77b1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Surface net downward shortwave flux</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>description :</span></dt><dd>This parameter is the amount of solar radiation (also known as shortwave radiation) that reaches a horizontal plane at the surface of the Earth (both direct and diffuse) minus the amount reflected by the Earth&#x27;s surface (which is governed by the albedo)</dd><dt><span>original_long_name :</span></dt><dd>Surface net solar radiation</dd><dt><span>original_variable :</span></dt><dd>ssr</dd><dt><span>standard_name :</span></dt><dd>surface_net_downward_shortwave_flux</dd><dt><span>units :</span></dt><dd>W m-2</dd><dt><span>_QuantizeBitRoundNumberOfSignificantDigits :</span></dt><dd>16</dd><dt><span>history :</span></dt><dd>[2025-09-08 10:22:47] Data compressed with BitRound by keeping 16 bits.</dd><dt><span>_ChunkSizes :</span></dt><dd>[1461   50   50]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -7439,13 +8007,13 @@
        "                    \n",
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
-       "                        <td> 2.33 GiB </td>\n",
+       "                        <td> 2.34 GiB </td>\n",
        "                        <td> 8.35 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
-       "                        <td> (27667, 111, 204) </td>\n",
+       "                        <td> (27698, 111, 204) </td>\n",
        "                        <td> (365, 60, 100) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
@@ -7484,9 +8052,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"73\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"62\" y2=\"77\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"81\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"85\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"84\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"73\" y2=\"88\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"77\" y2=\"92\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"92\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"96\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -7509,9 +8077,9 @@
        "  <line x1=\"58\" y1=\"48\" x2=\"83\" y2=\"48\" />\n",
        "  <line x1=\"62\" y1=\"52\" x2=\"87\" y2=\"52\" />\n",
        "  <line x1=\"65\" y1=\"55\" x2=\"91\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"95\" y2=\"59\" />\n",
+       "  <line x1=\"69\" y1=\"59\" x2=\"94\" y2=\"59\" />\n",
        "  <line x1=\"73\" y1=\"63\" x2=\"98\" y2=\"63\" />\n",
-       "  <line x1=\"77\" y1=\"67\" x2=\"102\" y2=\"67\" />\n",
+       "  <line x1=\"76\" y1=\"66\" x2=\"102\" y2=\"66\" />\n",
        "  <line x1=\"80\" y1=\"70\" x2=\"106\" y2=\"70\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -7540,11 +8108,11 @@
        "  <!-- Text -->\n",
        "  <text x=\"93.294544\" y=\"116.000852\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >204</text>\n",
        "  <text x=\"126.000852\" y=\"83.294544\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,126.000852,83.294544)\">111</text>\n",
-       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27667</text>\n",
+       "  <text x=\"35.294118\" y=\"80.706734\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,80.706734)\">27698</text>\n",
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-81855c08-b979-4c70-bc4b-3a5cbe2110f4' class='xr-section-summary-in' type='checkbox'  ><label for='section-81855c08-b979-4c70-bc4b-3a5cbe2110f4' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-ee747ecd-b3d5-4edd-b1e7-0b69584fba2b' class='xr-index-data-in' type='checkbox'/><label for='index-ee747ecd-b3d5-4edd-b1e7-0b69584fba2b' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([              44.0, 44.099998474121094,  44.20000076293945,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-c7313a99-b9ea-4436-940d-9c0b611ac47d' class='xr-section-summary-in' type='checkbox'  ><label for='section-c7313a99-b9ea-4436-940d-9c0b611ac47d' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-4839aefd-ce33-4be1-bf30-829ba46a7c1b' class='xr-index-data-in' type='checkbox'/><label for='index-4839aefd-ce33-4be1-bf30-829ba46a7c1b' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([              44.0, 44.099998474121094,  44.20000076293945,\n",
        "        44.29999923706055, 44.400001525878906,               44.5,\n",
        "       44.599998474121094,  44.70000076293945,  44.79999923706055,\n",
        "       44.900001525878906,\n",
@@ -7553,7 +8121,7 @@
        "       54.400001525878906,               54.5, 54.599998474121094,\n",
        "        54.70000076293945,  54.79999923706055, 54.900001525878906,\n",
        "                     55.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;lat&#x27;, length=111))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-2f3b0a40-0f56-4971-8f19-9ebc32dbf112' class='xr-index-data-in' type='checkbox'/><label for='index-2f3b0a40-0f56-4971-8f19-9ebc32dbf112' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([              -80.5,   -80.4000015258789,  -80.30000305175781,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;lat&#x27;, length=111))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-e9ec13ca-05a8-4230-ac66-ebd79c203b64' class='xr-index-data-in' type='checkbox'/><label for='index-e9ec13ca-05a8-4230-ac66-ebd79c203b64' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([              -80.5,   -80.4000015258789,  -80.30000305175781,\n",
        "        -80.19999694824219,   -80.0999984741211,               -80.0,\n",
        "         -79.9000015258789,  -79.80000305175781,  -79.69999694824219,\n",
        "         -79.5999984741211,\n",
@@ -7562,22 +8130,22 @@
        "        -60.79999923706055,  -60.70000076293945, -60.599998474121094,\n",
        "                     -60.5, -60.400001525878906,  -60.29999923706055,\n",
        "        -60.20000076293945],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;lon&#x27;, length=204))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-90ad20cf-c2ba-47d2-aefb-68121b30336a' class='xr-index-data-in' type='checkbox'/><label for='index-90ad20cf-c2ba-47d2-aefb-68121b30336a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1950-01-01&#x27;, &#x27;1950-01-02&#x27;, &#x27;1950-01-03&#x27;, &#x27;1950-01-04&#x27;,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;lon&#x27;, length=204))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-be36c79f-8d06-46ac-b403-2ab00f1160e3' class='xr-index-data-in' type='checkbox'/><label for='index-be36c79f-8d06-46ac-b403-2ab00f1160e3' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1950-01-01&#x27;, &#x27;1950-01-02&#x27;, &#x27;1950-01-03&#x27;, &#x27;1950-01-04&#x27;,\n",
        "               &#x27;1950-01-05&#x27;, &#x27;1950-01-06&#x27;, &#x27;1950-01-07&#x27;, &#x27;1950-01-08&#x27;,\n",
        "               &#x27;1950-01-09&#x27;, &#x27;1950-01-10&#x27;,\n",
        "               ...\n",
-       "               &#x27;2025-09-21&#x27;, &#x27;2025-09-22&#x27;, &#x27;2025-09-23&#x27;, &#x27;2025-09-24&#x27;,\n",
-       "               &#x27;2025-09-25&#x27;, &#x27;2025-09-26&#x27;, &#x27;2025-09-27&#x27;, &#x27;2025-09-28&#x27;,\n",
-       "               &#x27;2025-09-29&#x27;, &#x27;2025-09-30&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=27667, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3c254c2d-535b-4516-b5cc-2c49959a34ba' class='xr-section-summary-in' type='checkbox'  ><label for='section-3c254c2d-535b-4516-b5cc-2c49959a34ba' class='xr-section-summary' >Attributes: <span>(27)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.9</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>doi :</span></dt><dd>https://doi.org/10.24381/cds.e2161bac</dd><dt><span>domain :</span></dt><dd>NAM</dd><dt><span>frequency :</span></dt><dd>day</dd><dt><span>history :</span></dt><dd>[2022-12-25 09:07:39.901698] Converted variables and modified metadata for CF-like compliance. 2022-06-14 22:47:32 GMT by grib_to_netcdf-2.24.3: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data0/adaptor.mars.internal-1655246820.5771172-15214-2-143cd489-ece2-4311-85e6-aa6a10567823.nc /cache/tmp/143cd489-ece2-4311-85e6-aa6a10567823-adaptor.mars.internal-1655246683.1830711-15214-3-tmp.grib</dd><dt><span>institution :</span></dt><dd>ECMWF</dd><dt><span>intake_esm_dataset_key :</span></dt><dd>ECMWF_ERA5-Land_NAM.NAM.raw.D</dd><dt><span>intake_esm_vars :</span></dt><dd>tas</dd><dt><span>license :</span></dt><dd>Please acknowledge the use of ERA5-Land as stated in the Copernicus C3S/CAMS License agreement http://apps.ecmwf.int/datasets/licences/copernicus/</dd><dt><span>license_type :</span></dt><dd>permissive</dd><dt><span>processing_level :</span></dt><dd>raw</dd><dt><span>project :</span></dt><dd>era5-land</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>source :</span></dt><dd>ERA5-Land</dd><dt><span>table_date :</span></dt><dd>2022-12-21</dd><dt><span>table_id :</span></dt><dd>ECMWF</dd><dt><span>type :</span></dt><dd>reanalysis</dd><dt><span>format :</span></dt><dd>netcdf</dd><dt><span>title :</span></dt><dd>ERA5-Land : daily</dd><dt><span>institute :</span></dt><dd>European Centre for Medium-Range Weather Forecasts</dd><dt><span>institute_id :</span></dt><dd>ECMWF</dd><dt><span>dataset_id :</span></dt><dd>ERA5-Land</dd><dt><span>abstract :</span></dt><dd>ERA5-Land provides hourly high resolution information of surface variables. The data is a replay of the land component of the ERA5 climate reanalysis with a finer spatial resolution: ~9km grid spacing. ERA5-Land includes information about uncertainties for all variables at reduced spatial and temporal resolutions. The model used in the production of ERA5-Land is the tiled ECMWF Scheme for Surface Exchanges over Land incorporating land surface hydrology (H-TESSEL).</dd><dt><span>dataset_description :</span></dt><dd>https://www.ecmwf.int/en/era5-land</dd><dt><span>attribution :</span></dt><dd>Contains modified Copernicus Climate Change Service Information 2022. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus Information or Data it contains.</dd><dt><span>citation :</span></dt><dd>Muñoz Sabater, J., (2021): ERA5-Land hourly data from 1950 to 1980. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (Accessed on 2022.06.07)</dd></dl></div></li></ul></div></div>"
+       "               &#x27;2025-10-22&#x27;, &#x27;2025-10-23&#x27;, &#x27;2025-10-24&#x27;, &#x27;2025-10-25&#x27;,\n",
+       "               &#x27;2025-10-26&#x27;, &#x27;2025-10-27&#x27;, &#x27;2025-10-28&#x27;, &#x27;2025-10-29&#x27;,\n",
+       "               &#x27;2025-10-30&#x27;, &#x27;2025-10-31&#x27;],\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=27698, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c5c40538-2c7e-46b0-9dfe-7035d7a69d15' class='xr-section-summary-in' type='checkbox'  ><label for='section-c5c40538-2c7e-46b0-9dfe-7035d7a69d15' class='xr-section-summary' >Attributes: <span>(27)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.9</dd><dt><span>cell_methods :</span></dt><dd>time: mean (interval: 1 day)</dd><dt><span>doi :</span></dt><dd>https://doi.org/10.24381/cds.e2161bac</dd><dt><span>domain :</span></dt><dd>NAM</dd><dt><span>frequency :</span></dt><dd>day</dd><dt><span>history :</span></dt><dd>[2022-12-25 09:07:39.901698] Converted variables and modified metadata for CF-like compliance. 2022-06-14 22:47:32 GMT by grib_to_netcdf-2.24.3: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data0/adaptor.mars.internal-1655246820.5771172-15214-2-143cd489-ece2-4311-85e6-aa6a10567823.nc /cache/tmp/143cd489-ece2-4311-85e6-aa6a10567823-adaptor.mars.internal-1655246683.1830711-15214-3-tmp.grib</dd><dt><span>institution :</span></dt><dd>ECMWF</dd><dt><span>intake_esm_dataset_key :</span></dt><dd>ECMWF_ERA5-Land_NAM.NAM.raw.D</dd><dt><span>intake_esm_vars :</span></dt><dd>tas</dd><dt><span>license :</span></dt><dd>Please acknowledge the use of ERA5-Land as stated in the Copernicus C3S/CAMS License agreement http://apps.ecmwf.int/datasets/licences/copernicus/</dd><dt><span>license_type :</span></dt><dd>permissive</dd><dt><span>processing_level :</span></dt><dd>raw</dd><dt><span>project :</span></dt><dd>era5-land</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>source :</span></dt><dd>ERA5-Land</dd><dt><span>table_date :</span></dt><dd>2022-12-21</dd><dt><span>table_id :</span></dt><dd>ECMWF</dd><dt><span>type :</span></dt><dd>reanalysis</dd><dt><span>format :</span></dt><dd>netcdf</dd><dt><span>title :</span></dt><dd>ERA5-Land : daily</dd><dt><span>institute :</span></dt><dd>European Centre for Medium-Range Weather Forecasts</dd><dt><span>institute_id :</span></dt><dd>ECMWF</dd><dt><span>dataset_id :</span></dt><dd>ERA5-Land</dd><dt><span>abstract :</span></dt><dd>ERA5-Land provides hourly high resolution information of surface variables. The data is a replay of the land component of the ERA5 climate reanalysis with a finer spatial resolution: ~9km grid spacing. ERA5-Land includes information about uncertainties for all variables at reduced spatial and temporal resolutions. The model used in the production of ERA5-Land is the tiled ECMWF Scheme for Surface Exchanges over Land incorporating land surface hydrology (H-TESSEL).</dd><dt><span>dataset_description :</span></dt><dd>https://www.ecmwf.int/en/era5-land</dd><dt><span>attribution :</span></dt><dd>Contains modified Copernicus Climate Change Service Information 2022. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus Information or Data it contains.</dd><dt><span>citation :</span></dt><dd>Muñoz Sabater, J., (2021): ERA5-Land hourly data from 1950 to 1980. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (Accessed on 2022.06.07)</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 23GB\n",
-       "Dimensions:  (lat: 111, lon: 204, time: 27667)\n",
+       "Dimensions:  (lat: 111, lon: 204, time: 27698)\n",
        "Coordinates:\n",
        "  * lat      (lat) float32 444B 44.0 44.1 44.2 44.3 44.4 ... 54.7 54.8 54.9 55.0\n",
        "  * lon      (lon) float32 816B -80.5 -80.4 -80.3 -80.2 ... -60.4 -60.3 -60.2\n",
-       "  * time     (time) datetime64[ns] 221kB 1950-01-01 1950-01-02 ... 2025-09-30\n",
+       "  * time     (time) datetime64[ns] 222kB 1950-01-01 1950-01-02 ... 2025-10-31\n",
        "Data variables:\n",
        "    tas      (time, lat, lon) float32 3GB dask.array<chunksize=(365, 60, 6), meta=np.ndarray>\n",
        "    tasmin   (time, lat, lon) float32 3GB dask.array<chunksize=(365, 60, 6), meta=np.ndarray>\n",
@@ -7655,10 +8223,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:27.851385Z",
-     "iopub.status.busy": "2025-11-06T01:28:27.850811Z",
-     "iopub.status.idle": "2025-11-06T01:28:28.070513Z",
-     "shell.execute_reply": "2025-11-06T01:28:28.070002Z"
+     "iopub.execute_input": "2025-11-13T01:28:37.528581Z",
+     "iopub.status.busy": "2025-11-13T01:28:37.527913Z",
+     "iopub.status.idle": "2025-11-13T01:28:37.770739Z",
+     "shell.execute_reply": "2025-11-13T01:28:37.770212Z"
     },
     "tags": []
    },
@@ -7793,10 +8361,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:28.079834Z",
-     "iopub.status.busy": "2025-11-06T01:28:28.078714Z",
-     "iopub.status.idle": "2025-11-06T01:28:29.502373Z",
-     "shell.execute_reply": "2025-11-06T01:28:29.501849Z"
+     "iopub.execute_input": "2025-11-13T01:28:37.774628Z",
+     "iopub.status.busy": "2025-11-13T01:28:37.773675Z",
+     "iopub.status.idle": "2025-11-13T01:28:39.792622Z",
+     "shell.execute_reply": "2025-11-13T01:28:39.792091Z"
     },
     "tags": []
    },
@@ -7844,10 +8412,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:29.505264Z",
-     "iopub.status.busy": "2025-11-06T01:28:29.504647Z",
-     "iopub.status.idle": "2025-11-06T01:28:30.221036Z",
-     "shell.execute_reply": "2025-11-06T01:28:30.220501Z"
+     "iopub.execute_input": "2025-11-13T01:28:39.795538Z",
+     "iopub.status.busy": "2025-11-13T01:28:39.794837Z",
+     "iopub.status.idle": "2025-11-13T01:28:40.495800Z",
+     "shell.execute_reply": "2025-11-13T01:28:40.495293Z"
     },
     "tags": []
    },
@@ -7857,7 +8425,7 @@
      "output_type": "stream",
      "text": [
       "Subset time using start_date only\n",
-      "start: 1991-01-01T00:00:00.000000000;\tend: 2025-09-30T00:00:00.000000000\n",
+      "start: 1991-01-01T00:00:00.000000000;\tend: 2025-10-31T00:00:00.000000000\n",
       "\n"
      ]
     },
@@ -7902,10 +8470,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:30.224177Z",
-     "iopub.status.busy": "2025-11-06T01:28:30.223540Z",
-     "iopub.status.idle": "2025-11-06T01:28:31.003940Z",
-     "shell.execute_reply": "2025-11-06T01:28:31.003422Z"
+     "iopub.execute_input": "2025-11-13T01:28:40.498507Z",
+     "iopub.status.busy": "2025-11-13T01:28:40.498113Z",
+     "iopub.status.idle": "2025-11-13T01:28:41.272185Z",
+     "shell.execute_reply": "2025-11-13T01:28:41.271672Z"
     },
     "tags": []
    },
@@ -7945,10 +8513,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:31.011520Z",
-     "iopub.status.busy": "2025-11-06T01:28:31.010872Z",
-     "iopub.status.idle": "2025-11-06T01:28:32.507111Z",
-     "shell.execute_reply": "2025-11-06T01:28:32.506376Z"
+     "iopub.execute_input": "2025-11-13T01:28:41.275418Z",
+     "iopub.status.busy": "2025-11-13T01:28:41.274757Z",
+     "iopub.status.idle": "2025-11-13T01:28:43.181873Z",
+     "shell.execute_reply": "2025-11-13T01:28:43.181304Z"
     },
     "tags": []
    },
@@ -7991,10 +8559,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:32.510056Z",
-     "iopub.status.busy": "2025-11-06T01:28:32.509827Z",
-     "iopub.status.idle": "2025-11-06T01:28:33.203996Z",
-     "shell.execute_reply": "2025-11-06T01:28:33.203392Z"
+     "iopub.execute_input": "2025-11-13T01:28:43.184703Z",
+     "iopub.status.busy": "2025-11-13T01:28:43.184250Z",
+     "iopub.status.idle": "2025-11-13T01:28:44.190696Z",
+     "shell.execute_reply": "2025-11-13T01:28:44.190088Z"
     },
     "tags": []
    },
@@ -8034,10 +8602,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:33.207376Z",
-     "iopub.status.busy": "2025-11-06T01:28:33.207125Z",
-     "iopub.status.idle": "2025-11-06T01:28:33.472052Z",
-     "shell.execute_reply": "2025-11-06T01:28:33.471437Z"
+     "iopub.execute_input": "2025-11-13T01:28:44.193618Z",
+     "iopub.status.busy": "2025-11-13T01:28:44.193171Z",
+     "iopub.status.idle": "2025-11-13T01:28:44.456998Z",
+     "shell.execute_reply": "2025-11-13T01:28:44.456348Z"
     },
     "tags": []
    },
@@ -8074,10 +8642,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:33.480110Z",
-     "iopub.status.busy": "2025-11-06T01:28:33.479882Z",
-     "iopub.status.idle": "2025-11-06T01:28:34.162183Z",
-     "shell.execute_reply": "2025-11-06T01:28:34.161148Z"
+     "iopub.execute_input": "2025-11-13T01:28:44.460227Z",
+     "iopub.status.busy": "2025-11-13T01:28:44.459714Z",
+     "iopub.status.idle": "2025-11-13T01:28:45.474857Z",
+     "shell.execute_reply": "2025-11-13T01:28:45.474332Z"
     },
     "tags": []
    },
@@ -8143,10 +8711,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-11-06T01:28:34.167117Z",
-     "iopub.status.busy": "2025-11-06T01:28:34.166846Z",
-     "iopub.status.idle": "2025-11-06T01:28:46.579040Z",
-     "shell.execute_reply": "2025-11-06T01:28:46.578322Z"
+     "iopub.execute_input": "2025-11-13T01:28:45.478078Z",
+     "iopub.status.busy": "2025-11-13T01:28:45.477660Z",
+     "iopub.status.idle": "2025-11-13T01:28:58.736159Z",
+     "shell.execute_reply": "2025-11-13T01:28:58.735653Z"
     },
     "tags": []
    },


### PR DESCRIPTION
I did test the previous output refresh (https://github.com/Ouranosinc/PAVICS-landing/pull/118) but I guess the new data was uploaded again the next day after I merge ! :(  

This refresh should last until the end of the month.

Do we care that the output matches the data we have on our server?  Else I can add more `NBVAL_IGNORE_OUTPUT`.

To fix Jenkins error below:
```
  _ PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-2Subsetting.ipynb::Cell 1 _
  Notebook cell execution failed
  Cell 1: Cell outputs differ

  Input:
  from clisops.core import subset

  lon = [-75.4, -85, -65.5]  # Longitude
  lat = [46.67, 41, 55.3]  # Latitude

  ds_gridpoint = subset.subset_gridpoint(ds, lon=lon, lat=lat)
  display(ds_gridpoint)

  # Plot first year of tasmax data
  a = ds_gridpoint.tasmax.isel(time=slice(0, 365)).plot.line(x="time", figsize=(10, 4))

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    '<xarray.Data...ourly data...' == '<xarray.Data...ourly data...'

    Skipping 49 identical leading characters in diff, use -v to show
    Skipping 1564 identical trailing characters in diff, use -v to show
    -  time: 27698)
    ?           ^^
    +  time: 27667)
    ?           ^^
      Coordinates:
          lat      (site) float32 12B 46.7 41.0 55.3
          lon      (site) float32 12B -75.4 -85.0 -65.5
    -   * time     (time) datetime64[ns] 222kB/DATE/1950-01-02 ... 2025-10-31
    ?                                      ^                            -   ^
    +   * time     (time) datetime64[ns] 221kB/DATE/1950-01-02 ... 2025-09-30
    ?                                      ^                             +  ^
      Dimensio

  _ PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-2Subsetting.ipynb::Cell 3 _
  Notebook cell execution failed
  Cell 3: Cell outputs differ

  Input:
  # Specify the longitude and latitude boundaries
  lon_bnds = [-80.5, -60.2]
  lat_bnds = [44, 55]

  ds1 = subset.subset_bbox(ds, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
  display(ds1)

  # Plot a map of first timestep
  a = ds1.tasmax.isel(time=0).plot()

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    '<xarray.Data...ourly data...' == '<xarray.Data...ourly data...'

    Skipping 61 identical leading characters in diff, use -v to show
    Skipping 1581 identical trailing characters in diff, use -v to show
    -  time: 27698)
    ?           ^^
    +  time: 27667)
    ?           ^^
      Coordinates:
        * lat      (lat) float32 444B 44.0 44.1 44.2 44.3 44.4 ... 54.7 54.8 54.9 55.0
        * lon      (lon) float32 816B -80.5 -80.4 -80.3 -80.2 ... -60.4 -60.3 -60.2
    -   * time     (time) datetime64[ns] 222kB/DATE/1950-01-02 ... 2025-10-31
    ?                                      ^                            -   ^
    +   * time     (time) datetime64[ns] 221kB/DATE/1950-01-02 ... 2025-09-30
    ?                                      ^                             +  ^
      Data var

  _ PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-2Subsetting.ipynb::Cell 6 _
  Notebook cell execution failed
  Cell 6: Cell outputs differ

  Input:
  # Align data to a starting year
  ds_sub = subset.subset_time(ds, start_date="1991")
  print(
      f"Subset time using start_date only\nstart: {ds_sub.time.min().values};\tend: {ds_sub.time.max().values}\n"
  )

  # Select a temporal slice
  ds_sub = subset.subset_time(ds, start_date="1991-08-05", end_date="2017-06-15")
  print(
      f"Subset time using both start_date & end_date\nstart: {ds_sub.time.min().values};\tend: {ds_sub.time.max().values}"
  )

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    'Subset time ...0.000000000\n' == 'Subset time ...0.000000000\n'

    Skipping 72 identical leading characters in diff, use -v to show
    Skipping 130 identical trailing characters in diff, use -v to show
    - end: 2025-10-31T00:00:00
    ?           -   ^
    + end: 2025-09-30T00:00:00
    ?            +  ^
```